### PR TITLE
[FEAT]: HealthCheck API 구현 및 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.1'
+    id 'org.springframework.boot' version '3.4.1'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -19,8 +19,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/eatsfine/eatsfine/EatsfineApplication.java
+++ b/src/main/java/com/eatsfine/eatsfine/EatsfineApplication.java
@@ -3,6 +3,9 @@ package com.eatsfine.eatsfine;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+@ConfigurationPropertiesScan
 @SpringBootApplication
 public class EatsfineApplication {
 

--- a/src/main/java/com/eatsfine/eatsfine/controller/HealthController.java
+++ b/src/main/java/com/eatsfine/eatsfine/controller/HealthController.java
@@ -1,0 +1,21 @@
+package com.eatsfine.eatsfine.controller;
+
+import com.eatsfine.eatsfine.system.deploy.config.DeployProperties;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+    private final DeployProperties deployProperties;
+
+    public HealthController(DeployProperties deployProperties) {
+        this.deployProperties = deployProperties;
+    }
+
+    @GetMapping("/api/v1/deploy/health-check")
+    public ResponseEntity<String> healthCheck() {
+        return ResponseEntity.ok(deployProperties.profile());
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/system/deploy/config/DeployProperties.java
+++ b/src/main/java/com/eatsfine/eatsfine/system/deploy/config/DeployProperties.java
@@ -1,0 +1,7 @@
+package com.eatsfine.eatsfine.system.deploy.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "server")
+public record DeployProperties(String profile) {
+}

--- a/src/test/java/com/eatsfine/eatsfine/controller/HealthControllerTest.java
+++ b/src/test/java/com/eatsfine/eatsfine/controller/HealthControllerTest.java
@@ -1,0 +1,40 @@
+package com.eatsfine.eatsfine.controller;
+
+import com.eatsfine.eatsfine.system.deploy.config.DeployProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(controllers = HealthController.class)
+@EnableConfigurationProperties(DeployProperties.class)
+@AutoConfigureMockMvc
+@DisplayName("HealthController 중형 테스트: 스프링 MVC와 컨트롤러가 잘 결합하여 동작하는가?")
+class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("healthCheck : 현재 서버가 살아있다면 200 상태코드와 함께 활성화된 프로필을 문자열로 응답한다")
+    void healthCheckTest() throws Exception {
+        mockMvc
+                .perform(get("/api/v1/deploy/health-check"))
+                .andDo(print())
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType("text/plain;charset=UTF-8"),
+                        content().string("test") // active profile set to 'test'
+                );
+    }
+}


### PR DESCRIPTION
### 💡 작업 개요
- 무중단 배포 및 서버 상태 모니터링을 위한 HealthCheck API를 구현했습니다.

### ✅ 작업 내용
- [ v] 기능 개발
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 주석/포맷 정리
- [ v] 기타 설정

### 🧪 테스트 내용
- [v] 로컬 단위 테스트 통과 (`./gradlew test`)
- [v] API 응답 확인: `test` 프로필 환경에서 문자열 "test" 반환 확인
