### PR TITLE
[FEAT]: 로컬 개발 환경 구성을 위한 Docker Compose 및 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: eatsfine-local-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: eatsfine_local
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+
+  redis:
+    image: redis:alpine
+    container_name: eatsfine-local-redis
+    ports:
+      - "6379:6379"
+
+volumes:
+  mysql_data:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,8 +2,24 @@ server:
   port: 8080
   profile: local
 
+
 spring:
   config:
     activate:
       on-profile: local
-
+  datasource:
+    url: jdbc:mysql://localhost:3306/eatsfine_local?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: root
+    password: password
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  data:
+    redis:
+      host: localhost
+      port: 6379
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
### 💡 작업 개요
- 로컬 개발 환경에서 별도 설치 없이 DB(MySQL)와 Redis를 간편하게 실행할 수 있도록 Docker Compose 기반 환경을 구성했습니다.
- 로컬 실행 시 사용할 `local` 프로필 설정을 추가했습니다.

### ✅ 작업 내용
- [ ] 기능 개발
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 주석/포맷 정리
- [x] 기타 설정 (환경설정)

### 🧪 테스트 내용
**1. 인프라 실행**
터미널에서 `docker-compose up -d` 명령어 실행 시 컨테이너가 정상적으로 구동됨을 확인.
**2. 애플리케이션 연결 확인**
스프링 부트 실행 시(`Active profiles: local`), 로그상 에러 없이 DB 및 Redis에 정상 연결됨을 확인.

### 📝 기타 참고 사항
- 도커 데스크탑 설치하시고, docker-compose.yml, application-local.yml에서 password 각자가 설정한 password로 바꾸시고, 터미널에서 docker-compose up -d 명령어 치시면 됩니다.
