### PR TITLE
[REFACTOR]: ApiResponse 실패 응답을 BaseErrorCode 기반으로 통합

### DIFF
--- a/src/main/java/com/eatsfine/eatsfine/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/apiPayload/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.eatsfine.eatsfine.global.apiPayload;
 
 import com.eatsfine.eatsfine.global.apiPayload.code.BaseCode;
+import com.eatsfine.eatsfine.global.apiPayload.code.BaseErrorCode;
 import com.eatsfine.eatsfine.global.apiPayload.code.status.SuccessStatus;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -34,8 +35,11 @@ public class ApiResponse<T> {
                 result);
     }
 
-    public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
-        return new ApiResponse<>(false, code, message, data);
+    public static <T> ApiResponse<T> onFailure(BaseErrorCode code, T result) {
+        return new ApiResponse<>(false,
+                code.getReasonHttpStatus().getCode(),
+                code.getReasonHttpStatus().getMessage(),
+                result);
     }
 
 }


### PR DESCRIPTION
### 💡 작업 개요
- ApiResponse.onFailure()를 BaseErrorCode 기반으로 통하여 에러 코드, 메시지의 임의 변경 가능성을 줄였습니다.

### ✅ 작업 내용
- [ ] 기능 개발
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

### 🧪 테스트 내용

### 📝 기타 참고 사항
- 기존 ApiResponse.of()에서 getReasonHttpStatus()를 사용하고 있어서 성공/실패 응답 모두 동일한 기준으로 맞췄습니다.