### PR TITLE
[FEAT]: HTTPS 적용 및 NGINX Blue-Green 무중단 배포 전환 로직 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,7 +151,8 @@ jobs:
         run: |
           ssh eatsfine-ec2 << 'EOF'
             set -e
-            docker exec -i nginx bash -c 'echo "set \$service_url ${{ env.TARGET_UPSTREAM }};" > ~/nginx/service-env.inc && nginx -s reload'
+            echo "set \$service_url ${{ env.TARGET_UPSTREAM }};" > /home/ec2-user/nginx/service-env.inc
+            docker exec nginx nginx -s reload
           EOF
       - name: 기존 배포 컨테이너 정지
         run: |


### PR DESCRIPTION
### 💡 작업 개요
- eatsfine.co.kr 도메인에 HTTPS를 적용하고,  
  GitHub Actions 기반 Blue-Green 무중단 배포 시  
  Nginx upstream 전환이 정상 동작하도록 배포 로직을 수정했습니다.

---

### ✅ 작업 내용
- [ ] 기능 개발
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 주석/포맷 정리
- [x] 기타 설정

**상세 내용**
- Let's Encrypt(Certbot) 기반 SSL 인증서 발급 및 HTTPS 적용
- Nginx 설정에 80 → 443 리다이렉트 추가
- Nginx upstream 전환 방식을  
  👉 컨테이너 내부 수정 방식 → **EC2 호스트 파일 수정 방식**으로 변경
- `service-env.inc`를 호스트에서 수정 후 `nginx -s reload`로 무중단 전환
- GitHub Actions 배포 파이프라인에서 Blue ↔ Green 자동 전환 로직 안정화

---

### 🧪 테스트 내용
- HTTPS 접속 테스트 (`https://eatsfine.co.kr`)
- HTTP → HTTPS 리다이렉트 정상 동작 확인


---

### 📝 기타 참고 사항
- Nginx 설정 파일은 컨테이너 내부가 아닌  
  **EC2 호스트(`~/nginx/service-env.inc`)에서 관리**
- upstream 전환 시 컨테이너 재시작 없이 `nginx reload`만 수행
- 추후 인증서 자동 갱신(cron or GitHub Actions) 작업 추가 가능

