### PR TITLE
[FIX]: 배포 대상 판단 로직을 nginx upstream 기준으로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,46 +48,40 @@ jobs:
       - name: 도커 이미지 푸시
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/eatsfine-be:latest
 
-      - name: 배포 대상 포트/PROFILE 확인
+      - name: SSH Key 설정
         run: |
-          # curl 연결 실패 시(서버 꺼짐 등)에도 에러내지 않고 넘어감 (|| true)
-          response=$(curl -s -w "%{http_code}" "http://${{ secrets.LIVE_SERVER_IP }}/api/v1/deploy/health-check") || true
-          
-          echo "Response: $response"
-          
-          # 응답이 비어있거나(연결실패) 200이 아니면
-          if [ -z "$response" ] || [ "${#response}" -lt 3 ]; then
-            STATUS="ERROR"
-          else
-            STATUS="${response: -3}"
-            BODY="${response::-3}"
-          fi
-          
-          echo "STATUS=$STATUS"
-          
-          if [ "$STATUS" = "200" ]; then
-            CURRENT_UPSTREAM="$BODY"
-          else
-            # 서버가 죽어있거나 응답이 없으면 기본적으로 green을 현재 상태로 보고 blue를 배포
-            CURRENT_UPSTREAM="green"
-          fi
-          
-          echo "CURRENT_UPSTREAM=$CURRENT_UPSTREAM" >> $GITHUB_ENV
-          
-          if [ "$CURRENT_UPSTREAM" = "blue" ]; then
-            echo "CURRENT_PORT=${{ secrets.BLUE_PORT }}" >> $GITHUB_ENV
-            echo "STOPPED_PORT=${{ secrets.GREEN_PORT }}" >> $GITHUB_ENV
-            echo "TARGET_UPSTREAM=green" >> $GITHUB_ENV
-            echo "TARGET_PORT=${{ secrets.GREEN_PORT }}" >> $GITHUB_ENV
-          elif [ "$CURRENT_UPSTREAM" = "green" ]; then
-            echo "CURRENT_PORT=${{ secrets.GREEN_PORT }}" >> $GITHUB_ENV
-            echo "STOPPED_PORT=${{ secrets.BLUE_PORT }}" >> $GITHUB_ENV
-            echo "TARGET_UPSTREAM=blue" >> $GITHUB_ENV
-            echo "TARGET_PORT=${{ secrets.BLUE_PORT }}" >> $GITHUB_ENV
-          else
-            echo "error"
-            exit 1
-          fi
+          mkdir -p ~/.ssh
+          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/eatsfine-ec2-key.pem
+          chmod 600 ~/.ssh/eatsfine-ec2-key.pem
+          echo "Host eatsfine-ec2" >> ~/.ssh/config
+          echo "  HostName ${{ secrets.LIVE_SERVER_IP }}" >> ~/.ssh/config
+          echo "  User ${{ secrets.EC2_USERNAME }}" >> ~/.ssh/config
+          echo "  IdentityFile ~/.ssh/eatsfine-ec2-key.pem" >> ~/.ssh/config
+          echo "  StrictHostKeyChecking no" >> ~/.ssh/config
+
+      - name: 배포 대상 포트/PROFILE 확인 (nginx 기준)
+        run: |
+          ssh eatsfine-ec2 << 'EOF'
+            if [ -f /home/ec2-user/nginx/service-env.inc ]; then
+              CURRENT_UPSTREAM=$(awk '{print $3}' /home/ec2-user/nginx/service-env.inc | tr -d ';')
+            else
+              CURRENT_UPSTREAM="green"
+            fi
+
+            echo "CURRENT_UPSTREAM=$CURRENT_UPSTREAM"
+
+            if [ "$CURRENT_UPSTREAM" = "blue" ]; then
+              echo "CURRENT_PORT=${{ secrets.BLUE_PORT }}" >> $GITHUB_ENV
+              echo "STOPPED_PORT=${{ secrets.GREEN_PORT }}" >> $GITHUB_ENV
+              echo "TARGET_UPSTREAM=green" >> $GITHUB_ENV
+              echo "TARGET_PORT=${{ secrets.GREEN_PORT }}" >> $GITHUB_ENV
+            else
+              echo "CURRENT_PORT=${{ secrets.GREEN_PORT }}" >> $GITHUB_ENV
+              echo "STOPPED_PORT=${{ secrets.BLUE_PORT }}" >> $GITHUB_ENV
+              echo "TARGET_UPSTREAM=blue" >> $GITHUB_ENV
+              echo "TARGET_PORT=${{ secrets.BLUE_PORT }}" >> $GITHUB_ENV
+            fi
+          EOF
 
       - name: GitHub Actions 실행자 IP 얻어오기
         id: GITHUB_ACTIONS_IP
@@ -106,17 +100,8 @@ jobs:
             --group-id ${{ secrets.EC2_SECURITY_GROUP_ID }} \
             --ip-permissions \
               'IpProtocol=tcp,FromPort=${{ secrets.EC2_SSH_PORT }},ToPort=${{ secrets.EC2_SSH_PORT }},IpRanges=[{CidrIp=${{ steps.GITHUB_ACTIONS_IP.outputs.ipv4 }}/32}]' \
-              'IpProtocol=tcp,FromPort=${{ env.STOPPED_PORT }},ToPort=${{ env.STOPPED_PORT }},IpRanges=[{CidrIp=${{ steps.GITHUB_ACTIONS_IP.outputs.ipv4 }}/32}]'
-      - name: SSH Key 설정
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/eatsfine-ec2-key.pem
-          chmod 600 ~/.ssh/eatsfine-ec2-key.pem
-          echo "Host eatsfine-ec2" >> ~/.ssh/config
-          echo "  HostName ${{ secrets.LIVE_SERVER_IP }}" >> ~/.ssh/config
-          echo "  User ${{ secrets.EC2_USERNAME }}" >> ~/.ssh/config
-          echo "  IdentityFile ~/.ssh/eatsfine-ec2-key.pem" >> ~/.ssh/config
-          echo "  StrictHostKeyChecking no" >> ~/.ssh/config
+              'IpProtocol=tcp,FromPort=${{ env.TARGET_PORT }},ToPort=${{ env.TARGET_PORT }},IpRanges=[{CidrIp=${{ steps.GITHUB_ACTIONS_IP.outputs.ipv4 }}/32}]'
+      
 
       - name: 도커 이미지 풀링 및 컨테이너 실행
         run: |
@@ -124,7 +109,7 @@ jobs:
             set -e
           
             CONFIG_DIR=/home/ec2-user/config/eatsfine
-            DEPLOY_DIR=/home/ec2-user/deploy
+            mkdir -p $CONFIG_DIR
           
             # 필요한 프로필 파일을 서버로 복사합니다.
             if [ "${{ env.TARGET_UPSTREAM }}" = "blue" ]; then
@@ -162,8 +147,6 @@ jobs:
             if docker ps -a --format '{{.Names}}' | grep -q "^${{ env.CURRENT_UPSTREAM }}$"; then
               docker stop ${{ env.CURRENT_UPSTREAM }}
               docker rm ${{ env.CURRENT_UPSTREAM }}
-            else
-              echo "컨테이너 ${{ env.CURRENT_UPSTREAM }} 없음 - 스킵"
             fi
           EOF
       - name: GitHub Actions - SSH 및 컨테이너 실제 포트 접근 권한 제거
@@ -173,4 +156,4 @@ jobs:
           --group-id ${{ secrets.EC2_SECURITY_GROUP_ID }} \
           --ip-permissions \
             'IpProtocol=tcp,FromPort=${{ secrets.EC2_SSH_PORT }},ToPort=${{ secrets.EC2_SSH_PORT }},IpRanges=[{CidrIp=${{ steps.GITHUB_ACTIONS_IP.outputs.ipv4 }}/32}]' \
-            'IpProtocol=tcp,FromPort=${{env.STOPPED_PORT}},ToPort=${{env.STOPPED_PORT}},IpRanges=[{CidrIp=${{ steps.GITHUB_ACTIONS_IP.outputs.ipv4 }}/32}]'
+            'IpProtocol=tcp,FromPort=${{env.TARGET_PORT}},ToPort=${{env.TARGET_PORT}},IpRanges=[{CidrIp=${{ steps.GITHUB_ACTIONS_IP.outputs.ipv4 }}/32}]'


### PR DESCRIPTION
### 💡 작업 개요
- HTTPS 전환 이후 blue-green 무중단 배포가 정상 동작하지 않던 문제를 해결하기 위해
배포 대상 판단 로직을 외부 HTTP 요청 기반에서 nginx upstream 기준으로 수정했습니다.
- nginx가 실제로 트래픽을 전달 중인 upstream 정보를 기준으로
다음 배포 대상(blue/green)을 결정하도록 개선했습니다.

### ✅ 작업 내용
- [ ] 기능 개발
- [ v] 버그 수정
- [ v] 리팩토링
- [ ] 주석/포맷 정리
- [ v] 기타 설정

### 📝 기타 참고 사항
- 기존 curl http://IP/... 기반 배포 판단 로직은
HTTPS 리다이렉트 및 인증서 설정 변경 시 오동작 가능성이 있어 제거했습니다.
- 배포 판단 기준을 nginx 내부 설정(service-env.inc)으로 통일하여
HTTPS, certbot 갱신, nginx reload와 무관하게 안정적인 배포가 가능하도록 개선했습니다.
- 보안그룹 임시 오픈/원복 대상 포트는
새로 배포되는 TARGET 컨테이너 포트 기준으로 처리하도록 수정했습니다.
