### PR TITLE
[FEAT]: 결제 요청 API 구현 및 Booking 연동

### DIFF
--- a/src/main/java/com/eatsfine/eatsfine/domain/booking/entity/Booking.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/booking/entity/Booking.java
@@ -2,6 +2,7 @@ package com.eatsfine.eatsfine.domain.booking.entity;
 
 import com.eatsfine.eatsfine.domain.booking.entity.mapping.BookingTable;
 import com.eatsfine.eatsfine.domain.booking.enums.BookingStatus;
+import com.eatsfine.eatsfine.domain.payment.entity.Payment;
 import com.eatsfine.eatsfine.domain.store.entity.Store;
 import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
 import com.eatsfine.eatsfine.domain.user.entity.User;
@@ -38,10 +39,14 @@ public class Booking extends BaseEntity {
     @OneToMany(mappedBy = "booking", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BookingTable> bookingTables = new ArrayList<>();
 
+    @Builder.Default
+    @OneToMany(mappedBy = "booking", cascade = CascadeType.ALL) // 결제 내역은 중요하므로 orphanRemoval은 신중하게, 우선 제외
+    private List<Payment> payments = new ArrayList<>();
+
     @Column(name = "party_size", nullable = false)
     private Integer partySize;
 
-    //테이블 분리 허용 여부
+    // 테이블 분리 허용 여부
     @Builder.Default
     @Column(name = "is_split_accepted", nullable = false)
     private boolean isSplitAccepted = false;
@@ -53,7 +58,6 @@ public class Booking extends BaseEntity {
     // 예약 시간 (HH:mm)
     @Column(name = "booking_time", nullable = false)
     private LocalTime bookingTime;
-
 
     @Enumerated(EnumType.STRING)
     private BookingStatus status;

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/controller/PaymentController.java
@@ -1,0 +1,30 @@
+package com.eatsfine.eatsfine.domain.payment.controller;
+
+import com.eatsfine.eatsfine.domain.payment.dto.request.PaymentRequestDTO;
+import com.eatsfine.eatsfine.domain.payment.dto.response.PaymentResponseDTO;
+import com.eatsfine.eatsfine.domain.payment.service.PaymentService;
+import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Payment", description = "결제 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/payments")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @Operation(summary = "결제 요청", description = "예약 ID와 결제 제공자를 받아 결제를 요청합니다.")
+    @PostMapping("/request")
+    public ApiResponse<PaymentResponseDTO.PaymentRequestResultDTO> requestPayment(
+            @RequestBody @Valid PaymentRequestDTO.RequestPaymentDTO dto) {
+        return ApiResponse.onSuccess(paymentService.requestPayment(dto));
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/dto/request/PaymentRequestDTO.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/dto/request/PaymentRequestDTO.java
@@ -1,0 +1,14 @@
+package com.eatsfine.eatsfine.domain.payment.dto.request;
+
+import com.eatsfine.eatsfine.domain.payment.enums.PaymentProvider;
+import jakarta.validation.constraints.NotNull;
+
+public class PaymentRequestDTO {
+
+    public record RequestPaymentDTO(
+            @NotNull Long bookingId,
+            @NotNull PaymentProvider provider,
+            @NotNull String successUrl,
+            @NotNull String failUrl) {
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/dto/response/PaymentResponseDTO.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/dto/response/PaymentResponseDTO.java
@@ -1,0 +1,20 @@
+package com.eatsfine.eatsfine.domain.payment.dto.response;
+
+import com.eatsfine.eatsfine.domain.payment.enums.PaymentMethod;
+import com.eatsfine.eatsfine.domain.payment.enums.PaymentStatus;
+
+import java.time.LocalDateTime;
+
+public class PaymentResponseDTO {
+
+    public record PaymentRequestResultDTO(
+            Long paymentId,
+            Long bookingId,
+            PaymentMethod paymentMethod,
+            String tid,
+            Integer amount,
+            PaymentStatus paymentStatus,
+            String nextRedirectUrl,
+            LocalDateTime requestedAt) {
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/entity/Payment.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/entity/Payment.java
@@ -1,0 +1,72 @@
+package com.eatsfine.eatsfine.domain.payment.entity;
+
+import com.eatsfine.eatsfine.domain.booking.entity.Booking;
+import com.eatsfine.eatsfine.domain.payment.enums.PaymentMethod;
+import com.eatsfine.eatsfine.domain.payment.enums.PaymentProvider;
+import com.eatsfine.eatsfine.domain.payment.enums.PaymentStatus;
+import com.eatsfine.eatsfine.domain.payment.enums.PaymentType;
+import com.eatsfine.eatsfine.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "payment")
+public class Payment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booking_id", nullable = false)
+    private Booking booking;
+
+    @Column(name = "order_id", nullable = false)
+    private String orderId;
+
+    @Column(name = "amount", nullable = false)
+    private Integer amount;
+
+    @Column(name = "payment_key")
+    private String paymentKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_provider", nullable = false)
+    private PaymentProvider paymentProvider;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_method")
+    private PaymentMethod paymentMethod;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_status", nullable = false)
+    private PaymentStatus paymentStatus;
+
+    @Column(name = "requested_at", nullable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(name = "approved_at")
+    private LocalDateTime approvedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_type", nullable = false)
+    private PaymentType paymentType;
+
+    public void setPaymentKey(String paymentKey) {
+        this.paymentKey = paymentKey;
+    }
+
+    public void completePayment(LocalDateTime approvedAt, PaymentMethod method, String paymentKey) {
+        this.paymentStatus = PaymentStatus.COMPLETED;
+        this.approvedAt = approvedAt;
+        this.paymentMethod = method;
+        this.paymentKey = paymentKey;
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/enums/PaymentMethod.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/enums/PaymentMethod.java
@@ -1,0 +1,15 @@
+package com.eatsfine.eatsfine.domain.payment.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentMethod {
+    CARD("카드"),
+    VIRTUAL_ACCOUNT("가상계좌"),
+    SIMPLE_PAYMENT("간편결제"),
+    PHONE("휴대폰");
+
+    private final String description;
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/enums/PaymentProvider.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/enums/PaymentProvider.java
@@ -1,0 +1,13 @@
+package com.eatsfine.eatsfine.domain.payment.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentProvider {
+    KAKAOPAY("카카오페이"),
+    TOSS("토스");
+
+    private final String description;
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/enums/PaymentStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/enums/PaymentStatus.java
@@ -1,0 +1,15 @@
+package com.eatsfine.eatsfine.domain.payment.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentStatus {
+    PENDING("결제 대기"),
+    COMPLETED("결제 완료"),
+    FAILED("결제 실패"),
+    REFUNDED("환불 완료");
+
+    private final String description;
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/enums/PaymentType.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/enums/PaymentType.java
@@ -1,0 +1,13 @@
+package com.eatsfine.eatsfine.domain.payment.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentType {
+    DEPOSIT("예약금"),
+    REFUND("환불");
+
+    private final String description;
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package com.eatsfine.eatsfine.domain.payment.repository;
+
+import com.eatsfine.eatsfine.domain.payment.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/service/PaymentService.java
@@ -1,0 +1,67 @@
+package com.eatsfine.eatsfine.domain.payment.service;
+
+import com.eatsfine.eatsfine.domain.booking.entity.Booking;
+import com.eatsfine.eatsfine.domain.booking.repository.BookingRepository;
+import com.eatsfine.eatsfine.global.apiPayload.code.status.ErrorStatus;
+import com.eatsfine.eatsfine.global.apiPayload.exception.GeneralException;
+import com.eatsfine.eatsfine.domain.payment.dto.request.PaymentRequestDTO;
+import com.eatsfine.eatsfine.domain.payment.dto.response.PaymentResponseDTO;
+import com.eatsfine.eatsfine.domain.payment.entity.Payment;
+
+import com.eatsfine.eatsfine.domain.payment.enums.PaymentStatus;
+import com.eatsfine.eatsfine.domain.payment.enums.PaymentType;
+import com.eatsfine.eatsfine.domain.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+        private final PaymentRepository paymentRepository;
+        private final BookingRepository bookingRepository;
+
+        @Transactional
+        public PaymentResponseDTO.PaymentRequestResultDTO requestPayment(PaymentRequestDTO.RequestPaymentDTO dto) {
+                Booking booking = bookingRepository.findById(dto.bookingId())
+                                .orElseThrow(() -> new IllegalArgumentException("Booking not found"));
+
+                // 주문 ID 생성
+                String orderId = UUID.randomUUID().toString();
+
+                // 예약금 검증
+                if (booking.getDepositAmount() == null || booking.getDepositAmount() <= 0) {
+                        throw new GeneralException(ErrorStatus.PAYMENT_INVALID_DEPOSIT);
+                }
+
+                Payment payment = Payment.builder()
+                                .booking(booking)
+                                .orderId(orderId)
+                                .amount(booking.getDepositAmount())
+                                .paymentProvider(dto.provider())
+                                .paymentStatus(PaymentStatus.PENDING)
+                                .paymentType(PaymentType.DEPOSIT)
+                                .requestedAt(LocalDateTime.now())
+                                .build();
+
+                Payment savedPayment = paymentRepository.save(payment);
+
+                // 외부 결제 제공자 응답 모의 처리
+                String tid = "T" + UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+                String nextRedirectUrl = "https://mock.api.kakaopay.com/online/v1/payment/ready/" + tid;
+
+                return new PaymentResponseDTO.PaymentRequestResultDTO(
+                                savedPayment.getId(),
+                                booking.getId(),
+                                savedPayment.getPaymentMethod(),
+                                tid,
+                                savedPayment.getAmount(),
+                                savedPayment.getPaymentStatus(),
+                                nextRedirectUrl,
+                                savedPayment.getRequestedAt());
+        }
+}

--- a/src/main/java/com/eatsfine/eatsfine/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/apiPayload/code/status/ErrorStatus.java
@@ -13,7 +13,10 @@ public enum ErrorStatus implements BaseErrorCode {
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
-    _NOT_FOUND(HttpStatus.NOT_FOUND,"COMMON404","존재하지 않는 요청입니다.");
+    _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "존재하지 않는 요청입니다."),
+
+    // 예약금 관련 에러
+    PAYMENT_INVALID_DEPOSIT(HttpStatus.BAD_REQUEST, "PAYMENT4001", "예약금이 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,14 +8,14 @@ spring:
     activate:
       on-profile: local
   datasource:
-    url: jdbc:mysql://localhost:3306/eatsfine_local?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
-    username: root
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
### 💡 작업 개요
- 결제 요청 API를 구현하고 Booking 도메인과 연동했습니다.

### ✅ 작업 내용
- [v] 기능 개발
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

###상세 내용
- Payment 도메인(Entity, Repository, Service, Controller) 신규 생성
- 결제 요청 API: POST /api/v1/payments/request 구현
- Booking 연동: Booking 엔티티에 List<Payment> 추가 (1:N 관계 설정)
- 유효성 검증: 예약금(amount) 0원 이하 시 PAYMENT_INVALID_DEPOSIT 예외 처리
- Enum 추가: PaymentProvider, PaymentMethod, PaymentStatus 등 정의

### 🧪 테스트 내용
<img width="2896" height="1512" alt="image" src="https://github.com/user-attachments/assets/429a1c79-c821-499c-966d-a89d0a12eab1" />
<img width="2536" height="676" alt="image" src="https://github.com/user-attachments/assets/9cc909f6-66e0-4d56-99d9-ec2aee61bef5" />

- 로컬 환경에서 API 요청 테스트 완료 (Success)
- 정상 요청 시 Mock PG 응답(tid, nextRedirectUrl) 반환 확인

### 📝 기타 참고 사항
- 현재는 외부 PG사 연동 대신 Mock 데이터를 반환하도록 구현되어 있습니다.
- 추후 결제 승인 API 구현 시 실제 결제 완료 처리가 이루어질 예정입니다.
