### PR TITLE
[FEAT]: 가게 테이블(StoreTable) 도메인 엔티티 설계

### DIFF
--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/entity/StoreTable.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/entity/StoreTable.java
@@ -7,6 +7,8 @@ import com.eatsfine.eatsfine.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+
 @Entity
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,6 +30,12 @@ public class StoreTable extends BaseEntity {
 
     private Integer tableSeats; // 추후 삭제 예정
 
+    @Column(name = "min_seat_count", nullable = false)
+    private int minSeatCount;
+
+    @Column(name = "max_seat_count", nullable = false)
+    private int maxSeatCount;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "seats_type")
     private SeatsType seatsType;
@@ -44,5 +52,10 @@ public class StoreTable extends BaseEntity {
     @Column(name = "height_span", nullable = false)
     private int heightSpan;
 
+    @Builder.Default
+    @Column(name = "rating", precision = 2, scale = 1, nullable = false)
+    private BigDecimal rating = BigDecimal.ZERO;
 
+    @Column(name = "table_image_url")
+    private String tableImageUrl;
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/entity/StoreTable.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/entity/StoreTable.java
@@ -12,30 +12,36 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@Table(name = "store_table")
 public class StoreTable extends BaseEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "table_number", nullable = false, length = 30)
     private String tableNumber;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "table_layout_id", nullable = false)
     private TableLayout tableLayout; // 부모 변경
 
-    private Integer tableSeats;
+    private Integer tableSeats; // 추후 삭제 예정
 
     @Enumerated(EnumType.STRING)
     @Column(name = "seats_type")
     private SeatsType seatsType;
 
+    @Column(name = "grid_x", nullable = false)
     private int gridX;
 
+    @Column(name = "grid_y", nullable = false)
     private int gridY;
 
+    @Column(name = "width_span", nullable = false)
     private int widthSpan;
 
+    @Column(name = "height_span", nullable = false)
     private int heightSpan;
 
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/entity/StoreTable.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/entity/StoreTable.java
@@ -6,14 +6,19 @@ import com.eatsfine.eatsfine.domain.table_layout.entity.TableLayout;
 import com.eatsfine.eatsfine.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Entity
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@SQLDelete(sql = "UPDATE store_table SET is_deleted = true WHERE id = ?")
+@SQLRestriction("is_deleted = false")
 @Table(name = "store_table")
 public class StoreTable extends BaseEntity {
 
@@ -58,4 +63,11 @@ public class StoreTable extends BaseEntity {
 
     @Column(name = "table_image_url")
     private String tableImageUrl;
+
+    @Builder.Default
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/table_layout/entity/TableLayout.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/table_layout/entity/TableLayout.java
@@ -25,10 +25,13 @@ public class TableLayout extends BaseEntity {
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
+    @Column(name = "grid_rows", nullable = false)
     private int lows;
+
+    @Column(name = "grid_cols", nullable = false)
     private int cols;
 
-    @Column(name = "is_active")
+    @Column(name = "is_active", nullable = false)
     private boolean isActive;
 
     @OneToMany(mappedBy = "tableLayout")

--- a/src/main/java/com/eatsfine/eatsfine/domain/table_layout/entity/TableLayout.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/table_layout/entity/TableLayout.java
@@ -5,7 +5,9 @@ import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
 import com.eatsfine.eatsfine.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,6 +16,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@SQLRestriction("is_deleted = false")
 @Table(name = "table_layout")
 public class TableLayout extends BaseEntity {
 
@@ -33,6 +36,13 @@ public class TableLayout extends BaseEntity {
 
     @Column(name = "is_active", nullable = false)
     private boolean isActive;
+
+    @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
+    private boolean isDeleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     @OneToMany(mappedBy = "tableLayout", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<StoreTable> tables = new ArrayList<>();

--- a/src/main/java/com/eatsfine/eatsfine/domain/table_layout/entity/TableLayout.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/table_layout/entity/TableLayout.java
@@ -34,8 +34,7 @@ public class TableLayout extends BaseEntity {
     @Column(name = "is_active", nullable = false)
     private boolean isActive;
 
-    @OneToMany(mappedBy = "tableLayout")
+    @OneToMany(mappedBy = "tableLayout", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<StoreTable> tables = new ArrayList<>();
-
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/table_layout/entity/TableLayout.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/table_layout/entity/TableLayout.java
@@ -5,6 +5,7 @@ import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
 import com.eatsfine.eatsfine.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
@@ -16,6 +17,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@SQLDelete(sql = "UPDATE table_layout SET is_deleted = true WHERE id = ?")
 @SQLRestriction("is_deleted = false")
 @Table(name = "table_layout")
 public class TableLayout extends BaseEntity {

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/entity/TableBlock.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/entity/TableBlock.java
@@ -1,0 +1,35 @@
+package com.eatsfine.eatsfine.domain.tableblock.entity;
+
+import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
+import com.eatsfine.eatsfine.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "table_block")
+public class TableBlock extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_table_id", nullable = false)
+    private StoreTable storeTable;
+
+    @Column(name = "target_date", nullable = false)
+    private LocalDate targetDate;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/enums/SlotStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/enums/SlotStatus.java
@@ -1,0 +1,8 @@
+package com.eatsfine.eatsfine.domain.tableblock.enums;
+
+public enum SlotStatus {
+    AVAILABLE,
+    BOOKED,
+    BLOCKED,
+    BREAK_TIME
+}


### PR DESCRIPTION
### 💡 작업 개요
- 매장 테이블 배치도 관리와 예약 차단 기능을 위한 핵심 도메인 엔티티(TableLayout, StoreTable, TableBlock)를 설계하고 구현했습니다. 데이터 무결성을 보장하기 위해 Soft Delete 전략과 연관관계 매핑을 중점적으로 작업했습니다.

### ✅ 작업 내용
- [x] 기능 개발
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

### 🧪 테스트 내용
- 로컬 환경에서 애플리케이션 실행 확인
- DB 스키마 생성 정상 여부 확인

### 📝 기타 참고 사항
- **Soft Delete 전략 (Hibernate 어노테이션 활용)**
   - 예약 이력과의 데이터 정합성을 지키기 위해 물리적 삭제(Hard Delete) 대신 논리적 삭제(Soft Delete)를 택했습니다.
   - 매번 where 절을 붙이는 실수를 방지하기 위해 @SQLDelete와 @SQLRestriction을 적용하여 삭제 처리를 자동화했습니다.
 - **TableLayout 버전 관리**
   - 배치도를 새로 생성해도 기존 배치도와 테이블 정보는 예약 이력 조회를 위해 유지되어야 합니다. 따라서 기존 데이터를 지우지 않고 isActive 필드로 활성/비활성 상태를 관리하도록 했습니다.

Closes #49