### PR TITLE
[FEAT]: 가게 이미지, 테이블 이미지(S3) 업로드/조회/삭제 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,12 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
+    // amazon
+    implementation platform('software.amazon.awssdk:bom:2.25.17')
+
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:auth'
 }
 // --- QueryDSL ---
 def generated = 'build/generated/sources/annotationProcessor/java/main'

--- a/src/main/java/com/eatsfine/eatsfine/domain/image/exception/ImageException.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/image/exception/ImageException.java
@@ -1,0 +1,11 @@
+package com.eatsfine.eatsfine.domain.image.exception;
+
+
+import com.eatsfine.eatsfine.global.apiPayload.code.BaseErrorCode;
+import com.eatsfine.eatsfine.global.apiPayload.exception.GeneralException;
+
+public class ImageException extends GeneralException {
+    public ImageException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/image/status/ImageErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/image/status/ImageErrorStatus.java
@@ -11,7 +11,9 @@ import org.springframework.http.HttpStatus;
 public enum ImageErrorStatus implements BaseErrorCode {
     EMPTY_FILE(HttpStatus.BAD_REQUEST, "IMAGE4001", "업로드할 파일이 비어 있습니다."),
     INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "IMAGE4002", "지원하지 않는 파일 형식입니다."),
-    S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE5001", "이미지 업로드에 실패했습니다.");
+    S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE5001", "이미지 업로드에 실패했습니다."),
+    _IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE404", "해당하는 이미지가 존재하지 않습니다.")
+    ;
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/eatsfine/eatsfine/domain/image/status/ImageErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/image/status/ImageErrorStatus.java
@@ -1,0 +1,39 @@
+package com.eatsfine.eatsfine.domain.image.status;
+
+import com.eatsfine.eatsfine.global.apiPayload.code.BaseErrorCode;
+import com.eatsfine.eatsfine.global.apiPayload.code.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ImageErrorStatus implements BaseErrorCode {
+    EMPTY_FILE(HttpStatus.BAD_REQUEST, "IMAGE4001", "업로드할 파일이 비어 있습니다."),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "IMAGE4002", "지원하지 않는 파일 형식입니다."),
+    S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE5001", "이미지 업로드에 실패했습니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .isSuccess(true)
+                .message(message)
+                .code(code)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(true)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/controller/StoreController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/controller/StoreController.java
@@ -88,4 +88,15 @@ public class StoreController {
         return ApiResponse.of(StoreSuccessStatus._STORE_MAIN_IMAGE_UPLOAD_SUCCESS, storeCommandService.uploadMainImage(storeId, mainImage));
     }
 
+    @Operation(
+            summary = "식당 대표 이미지 조회",
+            description = "식당의 대표 이미지를 조회합니다."
+    )
+    @GetMapping("/stores/{storeId}/main-image")
+    public ApiResponse<StoreResDto.GetMainImageDto> getMainImage(
+            @PathVariable Long storeId
+    ) {
+        return ApiResponse.of(StoreSuccessStatus._STORE_MAIN_IMAGE_GET_SUCCESS, storeQueryService.getMainImage(storeId));
+    }
+
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/controller/StoreController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/controller/StoreController.java
@@ -12,7 +12,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Store", description = "식당 조회 및 관리 API")
 @RestController
@@ -70,5 +72,20 @@ public class StoreController {
         return ApiResponse.of(StoreSuccessStatus._STORE_UPDATE_SUCCESS, storeCommandService.updateBasicInfo(storeId, dto));
     }
 
+
+    @Operation(
+        summary = "식당 대표 이미지 등록",
+            description = "식당의 대표 이미지를 등록합니다."
+    )
+    @PostMapping(
+            value = "/stores/{storeId}/main-image",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ApiResponse<StoreResDto.UploadMainImageDto> uploadMainImage(
+            @RequestPart("mainImage")MultipartFile mainImage,
+            @PathVariable Long storeId
+            ){
+        return ApiResponse.of(StoreSuccessStatus._STORE_MAIN_IMAGE_UPLOAD_SUCCESS, storeCommandService.uploadMainImage(storeId, mainImage));
+    }
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/converter/StoreConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/converter/StoreConverter.java
@@ -72,5 +72,12 @@ public class StoreConverter {
                 .mainImageUrl(mainImageUrl)
                 .build();
     }
+
+    public static StoreResDto.GetMainImageDto toGetMainImageDto(Long storeId, String key) {
+        return StoreResDto.GetMainImageDto.builder()
+                .storeId(storeId)
+                .mainImageUrl(key)
+                .build();
+    }
 }
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/converter/StoreConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/converter/StoreConverter.java
@@ -5,7 +5,6 @@ import com.eatsfine.eatsfine.domain.businesshours.entity.BusinessHours;
 import com.eatsfine.eatsfine.domain.store.dto.StoreResDto;
 import com.eatsfine.eatsfine.domain.store.entity.Store;
 
-import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 
@@ -26,7 +25,7 @@ public class StoreConverter {
                 .rating(store.getRating())
                 .reviewCount(null) // 리뷰 도메인 구현 이후 추가 예정
                 .distance(distance)
-                .mainImageUrl(store.getMainImageUrl())
+                .mainImageUrl(store.getMainImageKey())
                 .isOpenNow(isOpenNow)
                 .build();
     }
@@ -46,7 +45,7 @@ public class StoreConverter {
                 .category(store.getCategory())
                 .rating(store.getRating())
                 .reviewCount(null) // reviewCount는 추후 리뷰 로직 구현 시 추가 예정
-                .mainImageUrl(store.getMainImageUrl())
+                .mainImageUrl(store.getMainImageKey())
                 .tableImageUrls(Collections.emptyList()) // tableImages는 추후 사진 등록 API 구현 시 추가 예정
                 .depositAmount(store.calculateDepositAmount())
                 .businessHours(

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/converter/StoreConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/converter/StoreConverter.java
@@ -4,6 +4,7 @@ import com.eatsfine.eatsfine.domain.businesshours.converter.BusinessHoursConvert
 import com.eatsfine.eatsfine.domain.businesshours.entity.BusinessHours;
 import com.eatsfine.eatsfine.domain.store.dto.StoreResDto;
 import com.eatsfine.eatsfine.domain.store.entity.Store;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Collections;
 import java.util.List;
@@ -62,6 +63,13 @@ public class StoreConverter {
         return StoreResDto.StoreUpdateDto.builder()
                 .storeId(storeId)
                 .updatedFields(updatedFields)
+                .build();
+    }
+
+    public static StoreResDto.UploadMainImageDto toUploadMainImageDto(Long storeId, String mainImageUrl) {
+        return StoreResDto.UploadMainImageDto.builder()
+                .storeId(storeId)
+                .mainImageUrl(mainImageUrl)
                 .build();
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/dto/StoreResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/dto/StoreResDto.java
@@ -81,5 +81,11 @@ public class StoreResDto {
             Long storeId,
             List<String> updatedFields
     ){};
+    // 가게 대표 이미지 조회 응답
+    @Builder
+    public record GetMainImageDto(
+            Long storeId,
+            String mainImageUrl
+    ) {}
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/dto/StoreResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/dto/StoreResDto.java
@@ -70,8 +70,9 @@ public class StoreResDto {
 
     // 가게 대표 이미지 등록 응답
     @Builder
-    public record uploadMainImageResDto(
-            String mainImageUrl
+    public record UploadMainImageDto(
+            Long storeId,
+            String mainImageKey
     ) {}
 
     // 식당 수정 응답

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/dto/StoreResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/dto/StoreResDto.java
@@ -72,7 +72,7 @@ public class StoreResDto {
     @Builder
     public record UploadMainImageDto(
             Long storeId,
-            String mainImageKey
+            String mainImageUrl
     ) {}
 
     // 식당 수정 응답

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/entity/Store.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/entity/Store.java
@@ -130,6 +130,11 @@ public class Store extends BaseEntity {
         tableImage.assignStore(null);
     }
 
+    // 가게 메인 이미지 등록
+    public void updateMainImageKey(String mainImageKey) {
+        this.mainImageKey = mainImageKey;
+    }
+
     // 특정 요일의 영업시간 조회 메서드
     public BusinessHours getBusinessHoursByDay(DayOfWeek dayOfWeek) {
         return this.businessHours.stream()
@@ -146,6 +151,7 @@ public class Store extends BaseEntity {
                 .findFirst();
     }
 
+    // 예약금 계산 메서드
     public BigDecimal calculateDepositAmount() {
         return BigDecimal.valueOf(minPrice)
                 .multiply(BigDecimal.valueOf(depositRate.getPercent()))

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/entity/Store.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/entity/Store.java
@@ -95,7 +95,6 @@ public class Store extends BaseEntity {
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TableImage> tableImages = new ArrayList<>();
 
-    // StoreTable이 아닌 TableLayout 엔티티 참조
 
     @Builder.Default
     @OneToMany(mappedBy = "store")

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/entity/Store.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/entity/Store.java
@@ -66,7 +66,7 @@ public class Store extends BaseEntity {
     private String address;
 
     @Column(name = "main_image_url")
-    private String mainImageUrl;
+    private String mainImageKey;
 
     @Builder.Default
     @Column(name = "rating", precision = 2, scale = 1, nullable = false)

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreCommandService.java
@@ -2,8 +2,10 @@ package com.eatsfine.eatsfine.domain.store.service;
 
 import com.eatsfine.eatsfine.domain.store.dto.StoreReqDto;
 import com.eatsfine.eatsfine.domain.store.dto.StoreResDto;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface StoreCommandService {
     StoreResDto.StoreCreateDto createStore(StoreReqDto.StoreCreateDto storeCreateDto);
     StoreResDto.StoreUpdateDto updateBasicInfo(Long storeId, StoreReqDto.StoreUpdateDto storeUpdateDto);
+    StoreResDto.UploadMainImageDto uploadMainImage(Long storeId, MultipartFile file);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreCommandServiceImpl.java
@@ -3,6 +3,8 @@ package com.eatsfine.eatsfine.domain.store.service;
 import com.eatsfine.eatsfine.domain.businesshours.converter.BusinessHoursConverter;
 import com.eatsfine.eatsfine.domain.businesshours.entity.BusinessHours;
 import com.eatsfine.eatsfine.domain.businesshours.validator.BusinessHoursValidator;
+import com.eatsfine.eatsfine.domain.image.exception.ImageException;
+import com.eatsfine.eatsfine.domain.image.status.ImageErrorStatus;
 import com.eatsfine.eatsfine.domain.region.entity.Region;
 import com.eatsfine.eatsfine.domain.region.repository.RegionRepository;
 import com.eatsfine.eatsfine.domain.region.status.RegionErrorStatus;
@@ -19,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import com.eatsfine.eatsfine.global.s3.S3Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
@@ -27,7 +31,9 @@ public class StoreCommandServiceImpl implements StoreCommandService {
 
     private final StoreRepository storeRepository;
     private final RegionRepository regionRepository;
+    private final S3Service s3Service;
 
+    // 가게 등록
     @Override
     public StoreResDto.StoreCreateDto createStore(StoreReqDto.StoreCreateDto dto) {
         Region region = regionRepository.findById(dto.regionId())
@@ -77,15 +83,37 @@ public class StoreCommandServiceImpl implements StoreCommandService {
     public List<String> extractUpdatedFields(StoreReqDto.StoreUpdateDto dto) {
         List<String> updated = new ArrayList<>();
 
-        if(dto.storeName() != null) updated.add("storeName");
-        if(dto.description() != null) updated.add("description");
-        if(dto.phoneNumber() != null) updated.add("phoneNumber");
-        if(dto.category() != null) updated.add("category");
-        if(dto.minPrice() != null) updated.add("minPrice");
-        if(dto.depositRate() != null) updated.add("depositRate");
-        if(dto.bookingIntervalMinutes() != null) updated.add("bookingIntervalMinutes");
+        if (dto.storeName() != null) updated.add("storeName");
+        if (dto.description() != null) updated.add("description");
+        if (dto.phoneNumber() != null) updated.add("phoneNumber");
+        if (dto.category() != null) updated.add("category");
+        if (dto.minPrice() != null) updated.add("minPrice");
+        if (dto.depositRate() != null) updated.add("depositRate");
+        if (dto.bookingIntervalMinutes() != null) updated.add("bookingIntervalMinutes");
 
         return updated;
+    }
+    // 가게 메인 이미지 등록
+    @Override
+    public StoreResDto.UploadMainImageDto uploadMainImage(Long storeId, MultipartFile file) {
+        Store store = storeRepository.findById(storeId).orElseThrow(
+                () -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND)
+        );
+
+        if(file.isEmpty()) {
+            throw new ImageException(ImageErrorStatus.EMPTY_FILE);
+        }
+
+        if(store.getMainImageKey() != null) {
+            s3Service.deleteByKey(store.getMainImageKey());
+        }
+
+        String key = s3Service.upload(file, "stores/" + storeId + "/main");
+        store.updateMainImageKey(key);
+
+        String mainImageUrl = s3Service.toUrl(store.getMainImageKey());
+
+        return StoreConverter.toUploadMainImageDto(store.getId(), mainImageUrl);
     }
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreCommandServiceImpl.java
@@ -42,7 +42,7 @@ public class StoreCommandServiceImpl implements StoreCommandService {
                 .businessNumber(dto.businessNumber())
                 .description(dto.description())
                 .address(dto.address())
-                .mainImageUrl(null) // 별도 API로 구현
+                .mainImageKey(null) // 별도 API로 구현
                 .region(region)
                 .phoneNumber(dto.phoneNumber())
                 .category(dto.category())

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryService.java
@@ -17,6 +17,8 @@ public interface StoreQueryService {
 
     StoreResDto.StoreDetailDto getStoreDetail(Long storeId);
 
+    StoreResDto.GetMainImageDto getMainImage(Long storeId);
+
     boolean isOpenNow(Store store, LocalDateTime now);
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryServiceImpl.java
@@ -5,8 +5,6 @@ import com.eatsfine.eatsfine.domain.store.converter.StoreConverter;
 import com.eatsfine.eatsfine.domain.store.dto.StoreResDto;
 import com.eatsfine.eatsfine.domain.store.dto.projection.StoreSearchResult;
 import com.eatsfine.eatsfine.domain.store.entity.Store;
-import com.eatsfine.eatsfine.domain.store.enums.Category;
-import com.eatsfine.eatsfine.domain.store.enums.StoreSortType;
 import com.eatsfine.eatsfine.domain.store.exception.StoreException;
 import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
 import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
@@ -16,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
@@ -24,6 +23,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class StoreQueryServiceImpl implements StoreQueryService {
 
     private final StoreRepository storeRepository;

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryServiceImpl.java
@@ -10,6 +10,7 @@ import com.eatsfine.eatsfine.domain.store.enums.StoreSortType;
 import com.eatsfine.eatsfine.domain.store.exception.StoreException;
 import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
 import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
+import com.eatsfine.eatsfine.global.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,6 +27,7 @@ import java.util.List;
 public class StoreQueryServiceImpl implements StoreQueryService {
 
     private final StoreRepository storeRepository;
+    private final S3Service s3Service;
 
     // 식당 검색
     @Override
@@ -71,6 +73,15 @@ public class StoreQueryServiceImpl implements StoreQueryService {
                 .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
 
         return StoreConverter.toDetailDto(store, isOpenNow(store, LocalDateTime.now()));
+    }
+
+    // 식당 대표 이미지 조회
+    @Override
+    public StoreResDto.GetMainImageDto getMainImage(Long storeId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+
+        return StoreConverter.toGetMainImageDto(storeId, s3Service.toUrl(store.getMainImageKey()));
     }
 
     // 현재 영업 여부 계산 (실시간 계산)

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreSuccessStatus.java
@@ -18,15 +18,11 @@ public enum StoreSuccessStatus implements BaseCode {
 
     _STORE_CREATED(HttpStatus.CREATED, "STORE201", "성공적으로 가게를 등록했습니다."),
 
-<<<<<<< HEAD
     _STORE_UPDATE_SUCCESS(HttpStatus.OK, "STORE2004", "성공적으로 가게 기본 정보를 수정했습니다."),
 
-    _STORE_MAIN_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "STORE2005", "성공적으로 가게 대표 이미지를 업로드했습니다.")
-=======
-    _STORE_MAIN_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "STORE2004", "성공적으로 가게 대표 이미지를 업로드했습니다."),
+    _STORE_MAIN_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "STORE2005", "성공적으로 가게 대표 이미지를 업로드했습니다."),
 
     _STORE_MAIN_IMAGE_GET_SUCCESS(HttpStatus.OK, "STORE2004", "성공적으로 가게 대표 이미지를 조회했습니다.")
->>>>>>> 4502c2b ([FEAT]: 가게 매인 이미지 조회 응답 DTO 및 성공 상태코드 추가)
     ;
 
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreSuccessStatus.java
@@ -22,7 +22,7 @@ public enum StoreSuccessStatus implements BaseCode {
 
     _STORE_MAIN_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "STORE2005", "성공적으로 가게 대표 이미지를 업로드했습니다."),
 
-    _STORE_MAIN_IMAGE_GET_SUCCESS(HttpStatus.OK, "STORE2004", "성공적으로 가게 대표 이미지를 조회했습니다.")
+    _STORE_MAIN_IMAGE_GET_SUCCESS(HttpStatus.OK, "STORE2005", "성공적으로 가게 대표 이미지를 조회했습니다.")
     ;
 
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreSuccessStatus.java
@@ -18,7 +18,9 @@ public enum StoreSuccessStatus implements BaseCode {
 
     _STORE_CREATED(HttpStatus.CREATED, "STORE201", "성공적으로 가게를 등록했습니다."),
 
-    _STORE_UPDATE_SUCCESS(HttpStatus.OK, "STORE2004", "성공적으로 가게 기본 정보를 수정했습니다.")
+    _STORE_UPDATE_SUCCESS(HttpStatus.OK, "STORE2004", "성공적으로 가게 기본 정보를 수정했습니다."),
+
+    _STORE_MAIN_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "STORE2005", "성공적으로 가게 대표 이미지를 업로드했습니다.")
     ;
 
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreSuccessStatus.java
@@ -18,9 +18,15 @@ public enum StoreSuccessStatus implements BaseCode {
 
     _STORE_CREATED(HttpStatus.CREATED, "STORE201", "성공적으로 가게를 등록했습니다."),
 
+<<<<<<< HEAD
     _STORE_UPDATE_SUCCESS(HttpStatus.OK, "STORE2004", "성공적으로 가게 기본 정보를 수정했습니다."),
 
     _STORE_MAIN_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "STORE2005", "성공적으로 가게 대표 이미지를 업로드했습니다.")
+=======
+    _STORE_MAIN_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "STORE2004", "성공적으로 가게 대표 이미지를 업로드했습니다."),
+
+    _STORE_MAIN_IMAGE_GET_SUCCESS(HttpStatus.OK, "STORE2004", "성공적으로 가게 대표 이미지를 조회했습니다.")
+>>>>>>> 4502c2b ([FEAT]: 가게 매인 이미지 조회 응답 DTO 및 성공 상태코드 추가)
     ;
 
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/controller/TableImageController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/controller/TableImageController.java
@@ -52,4 +52,17 @@ public class TableImageController {
         return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_GET_SUCCESS, tableImageQueryService.getTableImage(storeId));
     }
 
+    @Operation(
+            summary = "식당 테이블 이미지 삭제",
+            description = "식당 테이블 이미지를 삭제합니다."
+    )
+    @DeleteMapping("/stores/{storeId}/table-images")
+    ApiResponse<TableImageResDto.DeleteTableImageDto> deleteTableImage(
+            @PathVariable Long storeId,
+            @RequestBody List<Long> tableImageIds
+    ) {
+        return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_DELETE_SUCCESS, tableImageCommandService.deleteTableImage(storeId, tableImageIds));
+    }
+
+
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/controller/TableImageController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/controller/TableImageController.java
@@ -1,0 +1,40 @@
+package com.eatsfine.eatsfine.domain.tableimage.controller;
+
+import com.eatsfine.eatsfine.domain.tableimage.dto.TableImageResDto;
+import com.eatsfine.eatsfine.domain.tableimage.service.TableImageCommandService;
+import com.eatsfine.eatsfine.domain.tableimage.status.TableImageSuccessStatus;
+import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class TableImageController {
+
+    private final TableImageCommandService tableImageCommandService;
+
+    @Operation(
+            summary = "식당 테이블 이미지 등록",
+            description = "식당 테이블 이미지들을 등록합니다."
+    )
+    @PostMapping(
+            value = "/stores/{storeId}/table-images",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    ApiResponse<TableImageResDto.UploadTableImageDto> uploadTableImage(
+            @RequestPart("file") List<MultipartFile> files,
+            @PathVariable Long storeId
+    ) {
+        return ApiResponse.of(
+                TableImageSuccessStatus._STORE_TABLE_IMAGE_UPLOAD_SUCCESS,
+                tableImageCommandService.uploadTableImage(storeId, files)
+        );
+    }
+
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/controller/TableImageController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/controller/TableImageController.java
@@ -6,6 +6,7 @@ import com.eatsfine.eatsfine.domain.tableimage.service.TableImageQueryService;
 import com.eatsfine.eatsfine.domain.tableimage.status.TableImageSuccessStatus;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+@Tag(name = "TableImage", description = "테이블 이미지 조회 및 관리 API")
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/controller/TableImageController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/controller/TableImageController.java
@@ -2,6 +2,7 @@ package com.eatsfine.eatsfine.domain.tableimage.controller;
 
 import com.eatsfine.eatsfine.domain.tableimage.dto.TableImageResDto;
 import com.eatsfine.eatsfine.domain.tableimage.service.TableImageCommandService;
+import com.eatsfine.eatsfine.domain.tableimage.service.TableImageQueryService;
 import com.eatsfine.eatsfine.domain.tableimage.status.TableImageSuccessStatus;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,6 +19,7 @@ import java.util.List;
 public class TableImageController {
 
     private final TableImageCommandService tableImageCommandService;
+    private final TableImageQueryService tableImageQueryService;
 
     @Operation(
             summary = "식당 테이블 이미지 등록",
@@ -35,6 +37,17 @@ public class TableImageController {
                 TableImageSuccessStatus._STORE_TABLE_IMAGE_UPLOAD_SUCCESS,
                 tableImageCommandService.uploadTableImage(storeId, files)
         );
+    }
+
+    @Operation(
+            summary = "식당 테이블 이미지 조회",
+            description = "식당 테이블 이미지들을 조회합니다."
+    )
+    @GetMapping("/stores/{storeId}/table-images")
+    ApiResponse<TableImageResDto.GetTableImageDto>  getTableImage(
+            @PathVariable Long storeId
+    ) {
+        return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_GET_SUCCESS, tableImageQueryService.getTableImage(storeId));
     }
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/converter/TableImageConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/converter/TableImageConverter.java
@@ -1,16 +1,22 @@
 package com.eatsfine.eatsfine.domain.tableimage.converter;
 
 import com.eatsfine.eatsfine.domain.tableimage.dto.TableImageResDto;
-import com.eatsfine.eatsfine.domain.tableimage.entity.TableImage;
 
 import java.util.List;
 
 public class TableImageConverter {
 
-    public static TableImageResDto.UploadTableImageDto toTableImageDto(Long storeId, List<String> tableImages) {
+    public static TableImageResDto.UploadTableImageDto toUploadTableImageDto(Long storeId, List<String> tableImages) {
         return TableImageResDto.UploadTableImageDto.builder()
                 .storeId(storeId)
-                .tableImages(tableImages)
+                .tableImageUrls(tableImages)
+                .build();
+    }
+
+    public static TableImageResDto.GetTableImageDto toGetTableImageDto(Long storeId, List<String> tableImages) {
+        return TableImageResDto.GetTableImageDto.builder()
+                .storeId(storeId)
+                .tableImageUrls(tableImages)
                 .build();
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/converter/TableImageConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/converter/TableImageConverter.java
@@ -1,0 +1,16 @@
+package com.eatsfine.eatsfine.domain.tableimage.converter;
+
+import com.eatsfine.eatsfine.domain.tableimage.dto.TableImageResDto;
+import com.eatsfine.eatsfine.domain.tableimage.entity.TableImage;
+
+import java.util.List;
+
+public class TableImageConverter {
+
+    public static TableImageResDto.UploadTableImageDto toTableImageDto(Long storeId, List<String> tableImages) {
+        return TableImageResDto.UploadTableImageDto.builder()
+                .storeId(storeId)
+                .tableImages(tableImages)
+                .build();
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/converter/TableImageConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/converter/TableImageConverter.java
@@ -19,4 +19,11 @@ public class TableImageConverter {
                 .tableImageUrls(tableImages)
                 .build();
     }
+
+    public static TableImageResDto.DeleteTableImageDto toDeleteTableImageDto(Long storeId, List<Long> removedTableImages) {
+        return TableImageResDto.DeleteTableImageDto.builder()
+                .storeId(storeId)
+                .deletedTableImageIds(removedTableImages)
+                .build();
+    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/dto/TableImageResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/dto/TableImageResDto.java
@@ -9,6 +9,12 @@ public class TableImageResDto {
     @Builder
     public record UploadTableImageDto(
             Long storeId,
-            List<String> tableImages
+            List<String> tableImageUrls
+    ){}
+
+    @Builder
+    public record GetTableImageDto(
+            Long storeId,
+            List<String> tableImageUrls
     ){}
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/dto/TableImageResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/dto/TableImageResDto.java
@@ -17,4 +17,10 @@ public class TableImageResDto {
             Long storeId,
             List<String> tableImageUrls
     ){}
+
+    @Builder
+    public record DeleteTableImageDto(
+            Long storeId,
+            List<Long> deletedTableImageIds
+    ){}
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/dto/TableImageResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/dto/TableImageResDto.java
@@ -1,0 +1,14 @@
+package com.eatsfine.eatsfine.domain.tableimage.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+public class TableImageResDto {
+
+    @Builder
+    public record UploadTableImageDto(
+            Long storeId,
+            List<String> tableImages
+    ){}
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/entity/TableImage.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/entity/TableImage.java
@@ -22,7 +22,10 @@ public class TableImage extends BaseEntity {
     private Store store;
 
     @Column(name = "table_image_url", nullable = false)
-    private String tableImageUrl;
+    private String tableImageKey;
+
+    @Column(name = "image_order", nullable = false)
+    private int imageOrder;
 
     public void assignStore(Store store) {
         this.store = store;

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/repository/TableImageRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/repository/TableImageRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TableImageRepository extends JpaRepository<TableImage, Long> {
 
@@ -17,4 +18,6 @@ public interface TableImageRepository extends JpaRepository<TableImage, Long> {
     int findMaxOrderByStoreId(Long storeId);
 
     List<TableImage> findAllByStoreOrderByImageOrder(Store store);
+
+    Optional<TableImage> findByIdAndStore(Long id, Store store);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/repository/TableImageRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/repository/TableImageRepository.java
@@ -1,8 +1,11 @@
 package com.eatsfine.eatsfine.domain.tableimage.repository;
 
+import com.eatsfine.eatsfine.domain.store.entity.Store;
 import com.eatsfine.eatsfine.domain.tableimage.entity.TableImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface TableImageRepository extends JpaRepository<TableImage, Long> {
 
@@ -12,4 +15,6 @@ public interface TableImageRepository extends JpaRepository<TableImage, Long> {
     where ti.store.id = :storeId
 """)
     int findMaxOrderByStoreId(Long storeId);
+
+    List<TableImage> findAllByStoreOrderByImageOrder(Store store);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/repository/TableImageRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/repository/TableImageRepository.java
@@ -2,6 +2,14 @@ package com.eatsfine.eatsfine.domain.tableimage.repository;
 
 import com.eatsfine.eatsfine.domain.tableimage.entity.TableImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TableImageRepository extends JpaRepository<TableImage, Long> {
+
+    @Query("""
+    select coalesce(max(ti.imageOrder), 0)
+    from TableImage ti
+    where ti.store.id = :storeId
+""")
+    int findMaxOrderByStoreId(Long storeId);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageCommandService.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface TableImageCommandService {
 
     TableImageResDto.UploadTableImageDto uploadTableImage(Long storeId, List<MultipartFile> files);
+
+    TableImageResDto.DeleteTableImageDto deleteTableImage(Long storeId, List<Long> tableImageIds);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageCommandService.java
@@ -1,0 +1,11 @@
+package com.eatsfine.eatsfine.domain.tableimage.service;
+
+import com.eatsfine.eatsfine.domain.tableimage.dto.TableImageResDto;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface TableImageCommandService {
+
+    TableImageResDto.UploadTableImageDto uploadTableImage(Long storeId, List<MultipartFile> files);
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageCommandServiceImpl.java
@@ -50,6 +50,6 @@ public class TableImageCommandServiceImpl implements TableImageCommandService {
             store.addTableImage(tableImage);
             tableImages.add(s3Service.toUrl(key));
         }
-        return TableImageConverter.toTableImageDto(storeId, tableImages);
+        return TableImageConverter.toUploadTableImageDto(storeId, tableImages);
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageCommandServiceImpl.java
@@ -1,0 +1,55 @@
+package com.eatsfine.eatsfine.domain.tableimage.service;
+
+import com.eatsfine.eatsfine.domain.image.exception.ImageException;
+import com.eatsfine.eatsfine.domain.image.status.ImageErrorStatus;
+import com.eatsfine.eatsfine.domain.store.entity.Store;
+import com.eatsfine.eatsfine.domain.store.exception.StoreException;
+import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
+import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
+import com.eatsfine.eatsfine.domain.tableimage.converter.TableImageConverter;
+import com.eatsfine.eatsfine.domain.tableimage.dto.TableImageResDto;
+import com.eatsfine.eatsfine.domain.tableimage.entity.TableImage;
+import com.eatsfine.eatsfine.domain.tableimage.repository.TableImageRepository;
+import com.eatsfine.eatsfine.global.s3.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TableImageCommandServiceImpl implements TableImageCommandService {
+
+    private final StoreRepository storeRepository;
+    private final TableImageRepository tableImageRepository;
+    private final S3Service s3Service;
+
+    // 가게 테이블 이미지 등록
+    public TableImageResDto.UploadTableImageDto uploadTableImage(Long storeId, List<MultipartFile> files) {
+
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+
+        if(files == null || files.isEmpty() || files.stream().allMatch(MultipartFile::isEmpty)) {
+            throw new ImageException(ImageErrorStatus.EMPTY_FILE);
+        }
+
+        int imageOrder = tableImageRepository.findMaxOrderByStoreId(storeId) + 1;
+        List<String> tableImages = new ArrayList<>();
+
+        for (MultipartFile file : files) {
+            String key = s3Service.upload(file, "stores/" + storeId + "/tables");
+            TableImage tableImage = TableImage.builder()
+                    .tableImageKey(key)
+                    .imageOrder(imageOrder++)
+                    .build();
+            store.addTableImage(tableImage);
+            tableImages.add(s3Service.toUrl(key));
+        }
+        return TableImageConverter.toTableImageDto(storeId, tableImages);
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageQueryService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageQueryService.java
@@ -1,0 +1,7 @@
+package com.eatsfine.eatsfine.domain.tableimage.service;
+
+import com.eatsfine.eatsfine.domain.tableimage.dto.TableImageResDto;
+
+public interface TableImageQueryService {
+    TableImageResDto.GetTableImageDto getTableImage(Long storeId);
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageQueryServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageQueryServiceImpl.java
@@ -1,0 +1,41 @@
+package com.eatsfine.eatsfine.domain.tableimage.service;
+
+import com.eatsfine.eatsfine.domain.store.entity.Store;
+import com.eatsfine.eatsfine.domain.store.exception.StoreException;
+import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
+import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
+import com.eatsfine.eatsfine.domain.tableimage.converter.TableImageConverter;
+import com.eatsfine.eatsfine.domain.tableimage.dto.TableImageResDto;
+import com.eatsfine.eatsfine.domain.tableimage.entity.TableImage;
+import com.eatsfine.eatsfine.domain.tableimage.repository.TableImageRepository;
+import com.eatsfine.eatsfine.global.s3.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TableImageQueryServiceImpl implements TableImageQueryService {
+
+    private final StoreRepository storeRepository;
+    private final TableImageRepository tableImageRepository;
+    private final S3Service s3Service;
+
+    @Override
+    public TableImageResDto.GetTableImageDto getTableImage(Long storeId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+
+        List<TableImage> tableImages = tableImageRepository.findAllByStoreOrderByImageOrder(store);
+
+        List<String> tableImageUrls = tableImages.stream()
+                .map(ti-> s3Service.toUrl(ti.getTableImageKey()))
+                .toList();
+
+        return TableImageConverter.toGetTableImageDto(storeId, tableImageUrls);
+    }
+
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/status/TableImageSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/status/TableImageSuccessStatus.java
@@ -1,0 +1,44 @@
+package com.eatsfine.eatsfine.domain.tableimage.status;
+
+import com.eatsfine.eatsfine.global.apiPayload.code.BaseCode;
+import com.eatsfine.eatsfine.global.apiPayload.code.ReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TableImageSuccessStatus implements BaseCode {
+
+        _STORE_TABLE_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "STORE200", "성공적으로 가게 테이블 이미지를 업로드했습니다."),
+
+        _STORE_TABLE_IMAGE_GET_SUCCESS(HttpStatus.OK, "STORE2001", "성공적으로 가게 테이블 이미지를 조회했습니다.")
+        ;
+
+
+        private final HttpStatus httpStatus;
+        private final String code;
+        private final String message;
+
+        @Override
+        public ReasonDto getReason() {
+            return ReasonDto.builder()
+                    .isSuccess(true)
+                    .message(message)
+                    .code(code)
+                    .build();
+        }
+
+        @Override
+        public ReasonDto getReasonHttpStatus() {
+            return ReasonDto.builder()
+                    .isSuccess(true)
+                    .httpStatus(httpStatus)
+                    .message(message)
+                    .code(code)
+                    .build();
+        }
+
+    }
+
+

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/status/TableImageSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/status/TableImageSuccessStatus.java
@@ -10,9 +10,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum TableImageSuccessStatus implements BaseCode {
 
-        _STORE_TABLE_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "STORE200", "성공적으로 가게 테이블 이미지를 업로드했습니다."),
+        _STORE_TABLE_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "TABLE_IMAGE200", "성공적으로 가게 테이블 이미지를 업로드했습니다."),
 
-        _STORE_TABLE_IMAGE_GET_SUCCESS(HttpStatus.OK, "STORE2001", "성공적으로 가게 테이블 이미지를 조회했습니다.")
+        _STORE_TABLE_IMAGE_GET_SUCCESS(HttpStatus.OK, "TABLE_IMAGE2001", "성공적으로 가게 테이블 이미지를 조회했습니다.")
         ;
 
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/status/TableImageSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/status/TableImageSuccessStatus.java
@@ -12,7 +12,9 @@ public enum TableImageSuccessStatus implements BaseCode {
 
         _STORE_TABLE_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "TABLE_IMAGE200", "성공적으로 가게 테이블 이미지를 업로드했습니다."),
 
-        _STORE_TABLE_IMAGE_GET_SUCCESS(HttpStatus.OK, "TABLE_IMAGE2001", "성공적으로 가게 테이블 이미지를 조회했습니다.")
+        _STORE_TABLE_IMAGE_GET_SUCCESS(HttpStatus.OK, "TABLE_IMAGE2001", "성공적으로 가게 테이블 이미지를 조회했습니다."),
+
+        _STORE_TABLE_IMAGE_DELETE_SUCCESS(HttpStatus.OK, "TABLE_IMAGE2002", "성공적으로 가게 테이블 이미지를 삭제했습니다.")
         ;
 
 

--- a/src/main/java/com/eatsfine/eatsfine/global/config/S3Config.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/config/S3Config.java
@@ -1,0 +1,17 @@
+package com.eatsfine.eatsfine.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .build();
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/global/s3/S3Service.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/s3/S3Service.java
@@ -1,0 +1,76 @@
+package com.eatsfine.eatsfine.global.s3;
+
+import com.eatsfine.eatsfine.domain.image.exception.ImageException;
+import com.eatsfine.eatsfine.domain.image.status.ImageErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.base-url}")
+    private String baseUrl;
+
+    public String upload(MultipartFile file, String directory) {
+        String key = generateKey(file, directory);
+
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(request,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            return key;
+        } catch (IOException e) {
+            throw new ImageException(ImageErrorStatus.S3_UPLOAD_FAILED);
+        }
+    }
+
+    public void deleteByKey(String key) {
+        if (key == null || key.isBlank()) return;
+
+        s3Client.deleteObject(DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build());
+    }
+
+    public String toUrl(String key) {
+        if (key == null || key.isBlank()) return null;
+        return baseUrl + "/" + key;
+    }
+
+    private String generateKey(MultipartFile file, String directory) {
+        if(directory == null || directory.isBlank()) {
+            throw new IllegalArgumentException("S3 디렉토리는 비어있을 수 없습니다.");
+        }
+        String extension = extractExtension(file.getOriginalFilename());
+        return directory + "/" + UUID.randomUUID() + extension;
+    }
+
+    private String extractExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            throw new ImageException(ImageErrorStatus.INVALID_FILE_TYPE);
+        }
+        return filename.substring(filename.lastIndexOf("."));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,10 @@ spring:
     name: Eatsfine
   profiles:
     active: local
+
+cloud:
+  aws:
+    region: ap-northeast-2
+    s3:
+      bucket: eatsfine-images
+      base-url: https://eatsfine-images.s3.ap-northeast-2.amazonaws.com

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
 
 cloud:
   aws:
-    region: ap-northeast-2
+    region: ${AWS_REGION}
     s3:
-      bucket: eatsfine-images
-      base-url: https://eatsfine-images.s3.ap-northeast-2.amazonaws.com
+      bucket: ${AWS_S3_BUCKET}
+      base-url: ${AWS_S3_BASE_URL}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,3 +6,10 @@ spring:
   config:
     activate:
       on-profile: test
+
+cloud:
+  aws:
+    region: ap-northeast-2
+    s3:
+      bucket: eatsfine-images
+      base-url: https://eatsfine-images.s3.ap-northeast-2.amazonaws.com

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,10 +6,3 @@ spring:
   config:
     activate:
       on-profile: test
-
-cloud:
-  aws:
-    region: ap-northeast-2
-    s3:
-      bucket: eatsfine-images
-      base-url: https://eatsfine-images.s3.ap-northeast-2.amazonaws.com

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,3 +16,10 @@ spring:
 payment:
   toss:
     widget-secret-key: test_sk_sample_key_for_testing
+
+cloud:
+  aws:
+    region: ap-northeast-2
+    s3:
+      bucket: eatsfine-images
+      base-url: https://eatsfine-images.s3.ap-northeast-2.amazonaws.com

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -19,7 +19,7 @@ payment:
 
 cloud:
   aws:
-    region: ap-northeast-2
+    region: test-region
     s3:
-      bucket: eatsfine-images
-      base-url: https://eatsfine-images.s3.ap-northeast-2.amazonaws.com
+      bucket: test-bucket
+      base-url: https://test-bucket.s3.test-region.amazonaws.com


### PR DESCRIPTION
### 💡 작업 개요
- 가게의 대표 이미지 및 테이블 이미지(TableImage) 를 AWS S3에 업로드하고,
이미지의 S3 key를 기준으로 저장·조회·삭제 할 수 있도록 이미지 관련 기능을 구현했습니다.

- 이미지는 S3에 업로드 후 key 형태로 관리하여 향후 디렉토리 구조 변경에도 유연하게 대응할 수 있도록 설계했으며,
운영 환경에서는 EC2 IAM Role 기반 인증 방식을 사용해 S3에 접근하도록 구성했습니다.

- 가게 메인 이미지는 1장만 유지되며, 기존 이미지가 있을 경우 교체 시 자동으로 삭제됩니다.
테이블 이미지는 여러 장 등록 가능하고, imageOrder를 통해 등록 순서를 관리합니다.

Store 관련
- POST /api/v1/stores/{storeId}/main-image (식당 대표 이미지 등록) (식당 당 1장이라 기존 이미지 delete 후 등록))
- GET /api/v1/stores/{storeId}/main-image (식당 대표 이미지 조회)

TableImage 관련
- POST /api/v1/stores/{storeId}/table-images (식당 테이블 이미지 등록)
- GET /api/v1/stores/{storeId}/table-images (식당 테이블 이미지 조회)
- DELETE /api/v1/stores/{storeId}/table-images (식당 테이블 이미지 삭제)


### ✅ 작업 내용
- [x] 기능 개발
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 주석/포맷 정리
- [x] 기타 설정

### 🧪 테스트 내용
- 로컬 환경에서 빌드 정상 통과 확인
- API 기능 테스트는 CD 후 배포 서버에서 Swagger 기반으로 진행 예정

### 📝 기타 참고 사항
- AWS S3 접근은 Access Key / Secret Key를 코드에 포함하지 않고,
운영 환경에서는 EC2에 연결된 IAM Role을 통해 처리하도록 구성했습니다

- 이미지 조회는 S3 Public Read로 처리하고, 업로드·삭제 및 내부 조회는 EC2 IAM Role 권한을 통해 수행하도록 구성했습니다.

Closes #57 