### PR TITLE
[FEAT]: 테이블 예약 시간대 목록 조회, 관리 API 구현

### DIFF
--- a/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
@@ -26,4 +26,12 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
             "AND b.bookingDate = :date " +
             "AND b.status IN ('CONFIRMED', 'PENDING')")
     List<LocalTime> findBookedTimesByTableAndDate(@Param("tableId") Long tableId, @Param("date") LocalDate date);
+
+    @Query("SELECT COUNT(bt) > 0 FROM BookingTable bt " +
+            "JOIN bt.booking b " +
+            "WHERE bt.storeTable.id = :tableId " +
+            "AND b.bookingDate = :date " +
+            "AND b.bookingTime = :time " +
+            "AND b.status IN ('CONFIRMED', 'PENDING')")
+    boolean existsBookingByTableAndDateTime(@Param("tableId") Long tableId, @Param("date") LocalDate date, @Param("time") LocalTime time);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
@@ -19,4 +19,11 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
             "and b.bookingTime = :time " +
             "and b.status IN ('CONFIRMED', 'PENDING')")
     List<Long> findReservedTableIds(Long storeId, LocalDate date, LocalTime time);
+
+    @Query("SELECT b.bookingTime FROM BookingTable bt " +
+            "JOIN bt.booking b " +
+            "WHERE bt.storeTable.id = :tableId " +
+            "AND b.bookingDate = :date " +
+            "AND b.status IN ('CONFIRMED', 'PENDING')")
+    List<LocalTime> findBookedTimesByTableAndDate(@Param("tableId") Long tableId, @Param("date") LocalDate date);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
@@ -4,10 +4,14 @@ import com.eatsfine.eatsfine.domain.storetable.dto.req.StoreTableReqDto;
 import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
 import com.eatsfine.eatsfine.domain.storetable.exception.status.StoreTableSuccessStatus;
 import com.eatsfine.eatsfine.domain.storetable.service.StoreTableCommandService;
+import com.eatsfine.eatsfine.domain.storetable.service.StoreTableQueryService;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @Tag(name = "StoreTable", description = "가게 테이블 관리 API")
 @RestController
@@ -15,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1")
 public class StoreTableController implements StoreTableControllerDocs {
     private final StoreTableCommandService storeTableCommandService;
+    private final StoreTableQueryService storeTableQueryService;
 
     @PostMapping("/stores/{storeId}/tables")
     public ApiResponse<StoreTableResDto.TableCreateDto> createTable(
@@ -22,5 +27,15 @@ public class StoreTableController implements StoreTableControllerDocs {
             @RequestBody StoreTableReqDto.TableCreateDto dto
     ) {
         return ApiResponse.of(StoreTableSuccessStatus._TABLE_CREATED, storeTableCommandService.createTable(storeId, dto));
+    }
+
+    @GetMapping("/stores/{storeId}/tables/{tableId}/slots")
+    public ApiResponse<StoreTableResDto.SlotListDto> getTableSlots(
+            @PathVariable Long storeId,
+            @PathVariable Long tableId,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
+    ) {
+        LocalDate targetDate = (date != null) ? date : LocalDate.now();
+        return ApiResponse.of(StoreTableSuccessStatus._SLOT_LIST_FOUND, storeTableQueryService.getTableSlots(storeId, tableId, targetDate));
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
@@ -7,7 +7,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
 
 public interface StoreTableControllerDocs {
 
@@ -32,5 +36,36 @@ public interface StoreTableControllerDocs {
             @Parameter(description = "가게 ID", required = true, example = "1")
             Long storeId,
             @RequestBody @Valid StoreTableReqDto.TableCreateDto dto
+    );
+
+    @Operation(
+            summary = "테이블 예약 시간대 조회",
+            description = """                                                                                      
+                        특정 테이블의 예약 가능한 시간대를 조회합니다.
+                        - 동적 슬롯 생성 방식을 사용합니다.
+                        - 영업시간을 기준으로 예약 간격(bookingIntervalMinutes)만큼 슬롯을 생성합니다.
+                        - 각 슬롯의 상태는 다음과 같이 결정됩니다:
+                          * BREAK_TIME: 브레이크타임에 해당하는 시간대
+                          * BLOCKED: 사장이 차단한 시간대
+                          * BOOKED: 이미 예약된 시간대
+                          * AVAILABLE: 예약 가능한 시간대
+                        - date 파라미터가 없으면 오늘 날짜로 조회합니다.
+                        - 운영 시간 11:00~22:00, 예약 간격 30분이면 21:30이 마지막 슬롯입니다.
+                        """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "슬롯 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "테이블 또는 영업시간을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "테이블이 해당 가게에 속하지 않음")
+    })
+    ApiResponse<StoreTableResDto.SlotListDto> getTableSlots(
+            @Parameter(description = "가게 ID", required = true, example = "1")
+            Long storeId,
+
+            @Parameter(description = "테이블 ID", required = true, example = "1")
+            Long tableId,
+
+            @Parameter(description = "조회할 날짜 (yyyy-MM-dd 형식, 미입력 시 오늘 날짜)", example = "2026-01-12")
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
     );
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
@@ -2,6 +2,9 @@ package com.eatsfine.eatsfine.domain.storetable.converter;
 
 import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
 import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
+import com.eatsfine.eatsfine.domain.storetable.util.SlotCalculator;
+
+import java.util.List;
 
 public class StoreTableConverter {
     // StoreTable Entity를 생성 응답 DTO로 변환
@@ -19,6 +22,22 @@ public class StoreTableConverter {
                 .rating(table.getRating())
                 .reviewCount(0) // 리뷰 기능 미구현으로 0 반환
                 .tableImageUrl(table.getTableImageUrl())
+                .build();
+    }
+
+    public static StoreTableResDto.SlotListDto toSlotListDto(int totalCount, int availableCount, List<SlotCalculator.SlotDto> slots) {
+        List<StoreTableResDto.SlotDetailDto> slotDetails = slots.stream()
+                .map(slot -> StoreTableResDto.SlotDetailDto.builder()
+                        .time(slot.time())
+                        .status(slot.status())
+                        .isAvailable(slot.isAvailable())
+                        .build())
+                .toList();
+
+        return StoreTableResDto.SlotListDto.builder()
+                .totalSlotCount(totalCount)
+                .availableSlotCount(availableCount)
+                .slots(slotDetails)
                 .build();
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
@@ -1,9 +1,13 @@
 package com.eatsfine.eatsfine.domain.storetable.dto.res;
 
 import com.eatsfine.eatsfine.domain.storetable.enums.SeatsType;
+import com.eatsfine.eatsfine.domain.tableblock.enums.SlotStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 
 import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.List;
 
 public class StoreTableResDto {
     @Builder
@@ -20,5 +24,20 @@ public class StoreTableResDto {
             BigDecimal rating,
             Integer reviewCount,
             String tableImageUrl
+    ) {}
+
+    @Builder
+    public record SlotListDto(
+            int totalSlotCount,
+            int availableSlotCount,
+            List<SlotDetailDto> slots
+    ) {}
+
+    @Builder
+    public record SlotDetailDto(
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+            LocalTime time,
+            SlotStatus status,
+            boolean isAvailable
     ) {}
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableErrorStatus.java
@@ -10,10 +10,12 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum StoreTableErrorStatus implements BaseErrorCode {
 
-    _TABLE_NOT_FOUND(HttpStatus.NOT_FOUND, "TABLE404", "테이블을 찾을 수 없습니다."),
-    _TABLE_INVALID_SEAT_RANGE(HttpStatus.BAD_REQUEST, "TABLE400", "최소 인원은 최대 인원보다 작거나 같아야 합니다."),
-    _TABLE_POSITION_OUT_OF_BOUNDS(HttpStatus.BAD_REQUEST, "TABLE401", "테이블 위치가 배치도 그리드 범위를 벗어났습니다."),
-    _TABLE_POSITION_OVERLAPS(HttpStatus.BAD_REQUEST, "TABLE402", "해당 위치에 이미 다른 테이블이 존재합니다."),
+    _TABLE_NOT_FOUND(HttpStatus.NOT_FOUND, "TABLE404_1", "테이블을 찾을 수 없습니다."),
+    _TABLE_INVALID_SEAT_RANGE(HttpStatus.BAD_REQUEST, "TABLE400_1", "최소 인원은 최대 인원보다 작거나 같아야 합니다."),
+    _TABLE_POSITION_OUT_OF_BOUNDS(HttpStatus.BAD_REQUEST, "TABLE400_2", "테이블 위치가 배치도 그리드 범위를 벗어났습니다."),
+    _TABLE_POSITION_OVERLAPS(HttpStatus.BAD_REQUEST, "TABLE400_3", "해당 위치에 이미 다른 테이블이 존재합니다."),
+    _TABLE_NOT_BELONGS_TO_STORE(HttpStatus.BAD_REQUEST, "TABLE400_4", "해당 테이블은 해당 가게에 속하지 않습니다."),
+    _NO_BUSINESS_HOURS(HttpStatus.NOT_FOUND, "TABLE404_2", "해당 요일의 영업시간 정보를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableSuccessStatus.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum StoreTableSuccessStatus implements BaseCode {
 
-    _TABLE_CREATED(HttpStatus.CREATED, "TABLE201", "성공적으로 테이블을 생성했습니다."),
+    _TABLE_CREATED(HttpStatus.CREATED, "TABLE201_1", "성공적으로 테이블을 생성했습니다."),
+    _SLOT_LIST_FOUND(HttpStatus.OK, "TABLE200_1", "테이블 시간 슬롯 조회에 성공했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryService.java
@@ -1,0 +1,9 @@
+package com.eatsfine.eatsfine.domain.storetable.service;
+
+import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
+
+import java.time.LocalDate;
+
+public interface StoreTableQueryService {
+    StoreTableResDto.SlotListDto getTableSlots(Long storeId, Long tableId, LocalDate date);
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryServiceImpl.java
@@ -1,0 +1,52 @@
+package com.eatsfine.eatsfine.domain.storetable.service;
+
+import com.eatsfine.eatsfine.domain.booking.repository.BookingRepository;
+import com.eatsfine.eatsfine.domain.storetable.converter.StoreTableConverter;
+import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
+import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
+import com.eatsfine.eatsfine.domain.storetable.exception.StoreTableException;
+import com.eatsfine.eatsfine.domain.storetable.exception.status.StoreTableErrorStatus;
+import com.eatsfine.eatsfine.domain.storetable.repository.StoreTableRepository;
+import com.eatsfine.eatsfine.domain.storetable.util.SlotCalculator;
+import com.eatsfine.eatsfine.domain.storetable.validator.StoreTableValidator;
+import com.eatsfine.eatsfine.domain.tableblock.entity.TableBlock;
+import com.eatsfine.eatsfine.domain.tableblock.repository.TableBlockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreTableQueryServiceImpl implements StoreTableQueryService{
+    private final StoreTableRepository storeTableRepository;
+    private final TableBlockRepository tableBlockRepository;
+    private final BookingRepository bookingRepository;
+
+    // 테이블 슬롯 조회
+    @Override
+    public StoreTableResDto.SlotListDto getTableSlots(Long storeId, Long tableId, LocalDate date) {
+        StoreTable storeTable = storeTableRepository.findById(tableId)
+                .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._TABLE_NOT_FOUND));
+
+        StoreTableValidator.validateTableBelongsToStore(storeTable, storeId);
+
+        List<TableBlock> tableBlocks = tableBlockRepository.findByStoreTableAndTargetDate(storeTable, date);
+        List<LocalTime> bookedTimeList = bookingRepository.findBookedTimesByTableAndDate(tableId, date);
+        Set<LocalTime> bookedTimes = new HashSet<>(bookedTimeList);
+
+        SlotCalculator.SlotCalculationResult result = SlotCalculator.calculateSlots(storeTable, date, tableBlocks, bookedTimes);
+
+        return StoreTableConverter.toSlotListDto(
+                result.totalSlotCount(),
+                result.availableSlotCount(),
+                result.slots()
+        );
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/util/SlotCalculator.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/util/SlotCalculator.java
@@ -1,0 +1,140 @@
+package com.eatsfine.eatsfine.domain.storetable.util;
+
+import com.eatsfine.eatsfine.domain.businesshours.entity.BusinessHours;
+import com.eatsfine.eatsfine.domain.store.entity.Store;
+import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
+import com.eatsfine.eatsfine.domain.storetable.exception.StoreTableException;
+import com.eatsfine.eatsfine.domain.storetable.exception.status.StoreTableErrorStatus;
+import com.eatsfine.eatsfine.domain.tableblock.entity.TableBlock;
+import com.eatsfine.eatsfine.domain.tableblock.enums.SlotStatus;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SlotCalculator {
+
+    private SlotCalculator() {
+        // 인스턴스화 방지
+    }
+
+    // 테이블 슬롯 계산
+    public static SlotCalculationResult calculateSlots(StoreTable table, LocalDate date, List<TableBlock> tableBlocks, Set<LocalTime> bookedTimes) {
+        Store store = table.getTableLayout().getStore();
+        DayOfWeek dayOfWeek = date.getDayOfWeek();
+
+        BusinessHours businessHours = store.findBusinessHoursByDay(dayOfWeek)
+                .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._NO_BUSINESS_HOURS));
+
+        // 휴무일인 경우 빈 결과 반환
+        if (businessHours.isClosed()) {
+            return new SlotCalculationResult(0, 0, Collections.emptyList());
+        }
+
+        // 시간 슬롯 생성
+        List<TimeSlot> timeSlots = generateTimeSlots(
+                businessHours.getOpenTime(),
+                businessHours.getCloseTime(),
+                store.getBookingIntervalMinutes()
+        );
+
+        // 차단된 시간대 추출
+        Set<LocalTime> blockedTimes = extractBlockedTimes(tableBlocks);
+
+        // 각 슬롯의 상태 결정
+        List<SlotDto> slotDtoList = timeSlots.stream()
+                .map(slot -> determineSlotStatus(
+                        slot.time(),
+                        businessHours.getBreakStartTime(),
+                        businessHours.getBreakEndTime(),
+                        blockedTimes,
+                        bookedTimes
+                ))
+                .toList();
+
+        // 통계 계산
+        int totalCount = slotDtoList.size();
+        int availableCount = (int) slotDtoList.stream()
+                .filter(SlotDto::isAvailable)
+                .count();
+
+        return new SlotCalculationResult(totalCount, availableCount, slotDtoList);
+    }
+
+    // 영업시간 기준으로 시간 슬롯을 생성
+    public static List<TimeSlot> generateTimeSlots(
+            LocalTime openTime,
+            LocalTime closeTime,
+            int intervalMinutes
+    ) {
+        List<TimeSlot> slots = new ArrayList<>();
+        LocalTime current = openTime;
+
+        // 예: 22:00 종료, 30분 간격 → 21:30이 마지막
+        LocalTime lastSlotTime = closeTime.minusMinutes(intervalMinutes);
+
+        while (!current.isAfter(lastSlotTime)) {
+            slots.add(new TimeSlot(current));
+            current = current.plusMinutes(intervalMinutes);
+        }
+
+        return slots;
+    }
+
+    // TableBlock 엔티티 리스트에서 차단된 시간대를 추출
+    public static Set<LocalTime> extractBlockedTimes(List<TableBlock> tableBlocks) {
+        return tableBlocks.stream()
+                .map(TableBlock::getStartTime)
+                .collect(Collectors.toSet());
+    }
+
+    // 슬롯 상태 결정
+    public static SlotDto determineSlotStatus(
+            LocalTime slotTime,
+            LocalTime breakStart,
+            LocalTime breakEnd,
+            Set<LocalTime> blockedTimes,
+            Set<LocalTime> bookedTimes
+    ) {
+        // 브레이크 타임 체크
+        if (breakStart != null && breakEnd != null) {
+            if (!slotTime.isBefore(breakStart) && slotTime.isBefore(breakEnd)) {
+                return new SlotDto(slotTime, SlotStatus.BREAK_TIME, false);
+            }
+        }
+
+        // 차단 체크
+        if (blockedTimes.contains(slotTime)) {
+            return new SlotDto(slotTime, SlotStatus.BLOCKED, false);
+        }
+
+        // 예약 체크
+        if (bookedTimes.contains(slotTime)) {
+            return new SlotDto(slotTime, SlotStatus.BOOKED, false);
+        }
+
+        // 예약 가능
+        return new SlotDto(slotTime, SlotStatus.AVAILABLE, true);
+    }
+
+    public record SlotCalculationResult(
+            int totalSlotCount,
+            int availableSlotCount,
+            List<SlotDto> slots
+    ) {}
+
+    public record SlotDto(
+            LocalTime time,
+            SlotStatus status,
+            boolean isAvailable
+    ) {}
+
+    public record TimeSlot(
+            LocalTime time
+    ) {}
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/validator/StoreTableValidator.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/validator/StoreTableValidator.java
@@ -1,5 +1,6 @@
 package com.eatsfine.eatsfine.domain.storetable.validator;
 
+import com.eatsfine.eatsfine.domain.store.entity.Store;
 import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
 import com.eatsfine.eatsfine.domain.storetable.exception.StoreTableException;
 import com.eatsfine.eatsfine.domain.storetable.exception.status.StoreTableErrorStatus;
@@ -59,5 +60,13 @@ public class StoreTableValidator {
         boolean yOverlap = (newY <= existY2) && (newY2 >= existY1);
 
         return xOverlap && yOverlap;
+    }
+
+    // 테이블이 해당 가게에 속하는지 검증
+    public static void validateTableBelongsToStore(StoreTable table, Long storeId) {
+        Store store = table.getTableLayout().getStore();
+        if (!store.getId().equals(storeId)) {
+            throw new StoreTableException(StoreTableErrorStatus._TABLE_NOT_BELONGS_TO_STORE);
+        }
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/controller/TableBlockController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/controller/TableBlockController.java
@@ -1,0 +1,28 @@
+package com.eatsfine.eatsfine.domain.tableblock.controller;
+
+import com.eatsfine.eatsfine.domain.tableblock.dto.req.TableBlockReqDto;
+import com.eatsfine.eatsfine.domain.tableblock.dto.res.TableBlockResDto;
+import com.eatsfine.eatsfine.domain.tableblock.exception.status.TableBlockSuccessStatus;
+import com.eatsfine.eatsfine.domain.tableblock.service.TableBlockCommandService;
+import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "TableBlock", description = "테이블 슬롯 차단/해제 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class TableBlockController implements TableBlockControllerDocs {
+    private final TableBlockCommandService tableBlockCommandService;
+
+    @Override
+    @PatchMapping("/stores/{storeId}/tables/{tableId}/slots")
+    public ApiResponse<TableBlockResDto.SlotStatusUpdateDto> updateSlotStatus(
+            @PathVariable Long storeId,
+            @PathVariable Long tableId,
+            @RequestBody TableBlockReqDto.SlotStatusUpdateDto dto
+    ) {
+        return ApiResponse.of(TableBlockSuccessStatus._SLOT_STATUS_UPDATED, tableBlockCommandService.updateSlotStatus(storeId, tableId, dto));
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/controller/TableBlockControllerDocs.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/controller/TableBlockControllerDocs.java
@@ -1,0 +1,36 @@
+package com.eatsfine.eatsfine.domain.tableblock.controller;
+
+import com.eatsfine.eatsfine.domain.tableblock.dto.req.TableBlockReqDto;
+import com.eatsfine.eatsfine.domain.tableblock.dto.res.TableBlockResDto;
+import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface TableBlockControllerDocs {
+    @Operation(
+            summary = "테이블 슬롯 상태 변경",
+            description = """                                                                                      
+                        특정 테이블의 특정 시간대를 차단하거나 해제합니다.
+                        - BLOCKED: 해당 시간대를 차단합니다 (DB에 저장)
+                        - AVAILABLE: 차단을 해제합니다 (DB에서 삭제)
+                        차단된 시간대는 예약이 불가능하며, 슬롯 조회 시 BLOCKED 상태로 표시됩니다.
+                        """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "슬롯 상태 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 슬롯 상태 또는 테이블이 가게에 속하지 않음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "테이블을 찾을 수 없거나 차단 내역이 없음 (해제 시)")
+    })
+    ApiResponse<TableBlockResDto.SlotStatusUpdateDto> updateSlotStatus(
+            @Parameter(description = "가게 ID", required = true, example = "1")
+            Long storeId,
+
+            @Parameter(description = "테이블 ID", required = true, example = "1")
+            Long tableId,
+
+            @RequestBody @Valid TableBlockReqDto.SlotStatusUpdateDto dto
+    );
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/converter/TableBlockConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/converter/TableBlockConverter.java
@@ -1,0 +1,18 @@
+package com.eatsfine.eatsfine.domain.tableblock.converter;
+
+import com.eatsfine.eatsfine.domain.tableblock.dto.res.TableBlockResDto;
+import com.eatsfine.eatsfine.domain.tableblock.entity.TableBlock;
+import com.eatsfine.eatsfine.domain.tableblock.enums.SlotStatus;
+
+public class TableBlockConverter {
+    public static TableBlockResDto.SlotStatusUpdateDto toSlotStatusUpdateDto(TableBlock tableBlock, SlotStatus status) {
+        return TableBlockResDto.SlotStatusUpdateDto.builder()
+                .tableBlockId(tableBlock.getId())
+                .storeTableId(tableBlock.getStoreTable().getId())
+                .targetDate(tableBlock.getTargetDate())
+                .startTime(tableBlock.getStartTime())
+                .endTime(tableBlock.getEndTime())
+                .status(status)
+                .build();
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/dto/req/TableBlockReqDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/dto/req/TableBlockReqDto.java
@@ -1,0 +1,23 @@
+package com.eatsfine.eatsfine.domain.tableblock.dto.req;
+
+import com.eatsfine.eatsfine.domain.tableblock.enums.SlotStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class TableBlockReqDto {
+    public record SlotStatusUpdateDto(
+            @NotNull(message = "날짜는 필수입니다.")
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+            LocalDate targetDate,
+
+            @NotNull(message = "시작 시간은 필수입니다.")
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+            LocalTime startTime,
+
+            @NotNull(message = "상태는 필수입니다.")
+            SlotStatus status
+    ) {}
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/dto/res/TableBlockResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/dto/res/TableBlockResDto.java
@@ -1,0 +1,28 @@
+package com.eatsfine.eatsfine.domain.tableblock.dto.res;
+
+import com.eatsfine.eatsfine.domain.tableblock.enums.SlotStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class TableBlockResDto {
+    @Builder
+    public record SlotStatusUpdateDto(
+            Long tableBlockId,
+
+            Long storeTableId,
+
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+            LocalDate targetDate,
+
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+            LocalTime startTime,
+
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+            LocalTime endTime,
+
+            SlotStatus status
+    ) {}
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/exception/TableBlockException.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/exception/TableBlockException.java
@@ -1,0 +1,10 @@
+package com.eatsfine.eatsfine.domain.tableblock.exception;
+
+import com.eatsfine.eatsfine.global.apiPayload.code.BaseErrorCode;
+import com.eatsfine.eatsfine.global.apiPayload.exception.GeneralException;
+
+public class TableBlockException extends GeneralException {
+    public TableBlockException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/exception/status/TableBlockErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/exception/status/TableBlockErrorStatus.java
@@ -1,0 +1,41 @@
+package com.eatsfine.eatsfine.domain.tableblock.exception.status;
+
+import com.eatsfine.eatsfine.global.apiPayload.code.BaseErrorCode;
+import com.eatsfine.eatsfine.global.apiPayload.code.ErrorReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TableBlockErrorStatus implements BaseErrorCode {
+    _INVALID_SLOT_STATUS(HttpStatus.BAD_REQUEST, "BLOCK400_1", "유효하지 않은 슬롯 상태입니다. BLOCKED 또는 AVAILABLE만 가능합니다."),
+    _CANNOT_BLOCK_BOOKED_SLOT(HttpStatus.BAD_REQUEST, "BLOCK400_2", "이미 예약된 시간대는 차단할 수 없습니다."),
+    _CANNOT_UNBLOCK_BOOKED_SLOT(HttpStatus.BAD_REQUEST, "BLOCK400_3", "이미 예약된 시간대는 차단 해제 할 수 없습니다."),
+    _CANNOT_UNBLOCK_BREAK_TIME(HttpStatus.BAD_REQUEST, "BLOCK400_4", "브레이크타임은 영업시간 설정에서 변경할 수 있습니다."),
+    _TABLE_BLOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "BLOCK404_1", "해당 시간대에 차단 내역을 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDto getReason() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .message(message)
+                .code(code)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDto getReasonHttpStatus() {
+        return ErrorReasonDto.builder()
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .message(message)
+                .code(code)
+                .build();
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/exception/status/TableBlockSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/exception/status/TableBlockSuccessStatus.java
@@ -1,0 +1,37 @@
+package com.eatsfine.eatsfine.domain.tableblock.exception.status;
+
+import com.eatsfine.eatsfine.global.apiPayload.code.BaseCode;
+import com.eatsfine.eatsfine.global.apiPayload.code.ReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TableBlockSuccessStatus implements BaseCode {
+    _SLOT_STATUS_UPDATED(HttpStatus.OK, "BLOCK200_1", "테이블 슬롯 상태 변경에 성공했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDto getReason() {
+        return ReasonDto.builder()
+                .isSuccess(true)
+                .message(message)
+                .code(code)
+                .build();
+    }
+
+    @Override
+    public ReasonDto getReasonHttpStatus() {
+        return ReasonDto.builder()
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .message(message)
+                .code(code)
+                .build();
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/repository/TableBlockRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/repository/TableBlockRepository.java
@@ -5,8 +5,12 @@ import com.eatsfine.eatsfine.domain.tableblock.entity.TableBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface TableBlockRepository extends JpaRepository<TableBlock, Long> {
     List<TableBlock> findByStoreTableAndTargetDate(StoreTable storeTable, LocalDate targetDate);
+
+    Optional<TableBlock> findByStoreTableAndTargetDateAndStartTime(StoreTable storeTable, LocalDate targetDate, LocalTime startTime);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/repository/TableBlockRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/repository/TableBlockRepository.java
@@ -1,0 +1,12 @@
+package com.eatsfine.eatsfine.domain.tableblock.repository;
+
+import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
+import com.eatsfine.eatsfine.domain.tableblock.entity.TableBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface TableBlockRepository extends JpaRepository<TableBlock, Long> {
+    List<TableBlock> findByStoreTableAndTargetDate(StoreTable storeTable, LocalDate targetDate);
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/service/TableBlockCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/service/TableBlockCommandService.java
@@ -1,0 +1,8 @@
+package com.eatsfine.eatsfine.domain.tableblock.service;
+
+import com.eatsfine.eatsfine.domain.tableblock.dto.req.TableBlockReqDto;
+import com.eatsfine.eatsfine.domain.tableblock.dto.res.TableBlockResDto;
+
+public interface TableBlockCommandService {
+    TableBlockResDto.SlotStatusUpdateDto updateSlotStatus(Long storeId, Long tableId, TableBlockReqDto.SlotStatusUpdateDto dto);
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/service/TableBlockCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/service/TableBlockCommandServiceImpl.java
@@ -1,0 +1,95 @@
+package com.eatsfine.eatsfine.domain.tableblock.service;
+
+import com.eatsfine.eatsfine.domain.booking.repository.BookingRepository;
+import com.eatsfine.eatsfine.domain.store.entity.Store;
+import com.eatsfine.eatsfine.domain.store.exception.StoreException;
+import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
+import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
+import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
+import com.eatsfine.eatsfine.domain.storetable.exception.StoreTableException;
+import com.eatsfine.eatsfine.domain.storetable.exception.status.StoreTableErrorStatus;
+import com.eatsfine.eatsfine.domain.storetable.repository.StoreTableRepository;
+import com.eatsfine.eatsfine.domain.storetable.validator.StoreTableValidator;
+import com.eatsfine.eatsfine.domain.tableblock.converter.TableBlockConverter;
+import com.eatsfine.eatsfine.domain.tableblock.dto.req.TableBlockReqDto;
+import com.eatsfine.eatsfine.domain.tableblock.dto.res.TableBlockResDto;
+import com.eatsfine.eatsfine.domain.tableblock.entity.TableBlock;
+import com.eatsfine.eatsfine.domain.tableblock.enums.SlotStatus;
+import com.eatsfine.eatsfine.domain.tableblock.exception.TableBlockException;
+import com.eatsfine.eatsfine.domain.tableblock.exception.status.TableBlockErrorStatus;
+import com.eatsfine.eatsfine.domain.tableblock.repository.TableBlockRepository;
+import com.eatsfine.eatsfine.domain.tableblock.validator.TableBlockValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TableBlockCommandServiceImpl implements TableBlockCommandService {
+    private final StoreTableRepository storeTableRepository;
+    private final TableBlockRepository tableBlockRepository;
+    private final StoreRepository storeRepository;
+    private final BookingRepository bookingRepository;
+
+    // 테이블 슬롯 상태 변경
+    @Override
+    public TableBlockResDto.SlotStatusUpdateDto updateSlotStatus(Long storeId, Long tableId, TableBlockReqDto.SlotStatusUpdateDto dto) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+
+        StoreTable table = storeTableRepository.findById(tableId)
+                .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._TABLE_NOT_FOUND));
+
+        StoreTableValidator.validateTableBelongsToStore(table, storeId);
+
+        // 브레이크 타임 시간대라면 예외
+        TableBlockValidator.validateBreakTime(store, dto.targetDate(), dto.startTime());
+
+        // 예약 여부 조회
+        boolean isBooked = bookingRepository.existsBookingByTableAndDateTime(tableId, dto.targetDate(), dto.startTime());
+
+        // 슬롯 차단
+        if (dto.status() == SlotStatus.BLOCKED) {
+            TableBlockValidator.validateBlockBooking(isBooked);
+
+            Optional<TableBlock> existingBlock = tableBlockRepository
+                    .findByStoreTableAndTargetDateAndStartTime(table, dto.targetDate(), dto.startTime());
+
+            if (existingBlock.isPresent()) {
+                return TableBlockConverter.toSlotStatusUpdateDto(existingBlock.get(), SlotStatus.BLOCKED);
+            }
+
+            LocalTime endTime = dto.startTime().plusMinutes(store.getBookingIntervalMinutes());
+
+            TableBlock tableBlock = TableBlock.builder()
+                    .storeTable(table)
+                    .targetDate(dto.targetDate())
+                    .startTime(dto.startTime())
+                    .endTime(endTime)
+                    .build();
+
+            TableBlock savedBlock = tableBlockRepository.save(tableBlock);
+
+            return TableBlockConverter.toSlotStatusUpdateDto(savedBlock, SlotStatus.BLOCKED);
+        }
+
+        // 슬롯 차단 해제
+        if (dto.status() == SlotStatus.AVAILABLE) {
+            TableBlockValidator.validateUnblockBooking(isBooked);
+
+            TableBlock tableBlock = tableBlockRepository
+                    .findByStoreTableAndTargetDateAndStartTime(table, dto.targetDate(), dto.startTime())
+                    .orElseThrow(() -> new TableBlockException(TableBlockErrorStatus._TABLE_BLOCK_NOT_FOUND));
+
+            tableBlockRepository.delete(tableBlock);
+
+            return TableBlockConverter.toSlotStatusUpdateDto(tableBlock, SlotStatus.AVAILABLE);
+        }
+
+        throw new TableBlockException(TableBlockErrorStatus._INVALID_SLOT_STATUS);
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/validator/TableBlockValidator.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/validator/TableBlockValidator.java
@@ -1,0 +1,50 @@
+package com.eatsfine.eatsfine.domain.tableblock.validator;
+
+import com.eatsfine.eatsfine.domain.businesshours.entity.BusinessHours;
+import com.eatsfine.eatsfine.domain.store.entity.Store;
+import com.eatsfine.eatsfine.domain.tableblock.exception.TableBlockException;
+import com.eatsfine.eatsfine.domain.tableblock.exception.status.TableBlockErrorStatus;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class TableBlockValidator {
+    private TableBlockValidator() {
+        // 인스턴스화 방지
+    }
+
+    // 브레이크 타임 검증
+    public static void validateBreakTime(Store store, LocalDate targetDate, LocalTime startTime) {
+        DayOfWeek dayOfWeek = targetDate.getDayOfWeek();
+        BusinessHours businessHours = store.getBusinessHoursByDay(dayOfWeek);
+
+        boolean isBreakTime = isWithinBreakTime(businessHours.getBreakStartTime(), businessHours.getBreakEndTime(), startTime);
+
+        if (isBreakTime) {
+            throw new TableBlockException(TableBlockErrorStatus._CANNOT_UNBLOCK_BREAK_TIME);
+        }
+    }
+
+    public static boolean isWithinBreakTime(LocalTime breakStart, LocalTime breakEnd, LocalTime time) {
+        if (breakStart == null || breakEnd == null) {
+            return false;
+        }
+
+        return !time.isBefore(breakStart) && time.isBefore(breakEnd);
+    }
+
+    // 차단 시 예약 시간대 검증
+    public static void validateBlockBooking(boolean isBooked) {
+        if (isBooked) {
+            throw new TableBlockException(TableBlockErrorStatus._CANNOT_BLOCK_BOOKED_SLOT);
+        }
+    }
+
+    // 차단 해제시 예약 시간대 검증
+    public static void validateUnblockBooking(boolean isBooked) {
+        if (isBooked) {
+            throw new TableBlockException(TableBlockErrorStatus._CANNOT_UNBLOCK_BOOKED_SLOT);
+        }
+    }
+}


### PR DESCRIPTION
### 💡 작업 개요
#### **1. 예약 시간대 목록 조회 (GET)**
* **동적 슬롯 생성**: 모든 시간대를 DB에 저장하지 않고, API 호출 시점에 가게 설정에 맞춰 슬롯을 계산합니다.
* **검증 로직**:
    * 가게의 브레이크 타임 포함 여부 확인
    * 해당 테이블의 기존 예약 내역 대조
    * 관리자가 설정한 미운영(Blocked) 상태 반영

#### **2. 슬롯 상태 관리 (PATCH)**
* 특정 예약 시간대의 운영/미운영 상태를 전환하는 기능
* 검증: 브레이크 타임이나 이미 예약된 슬롯을 강제로 '운영' 상태로 변경하는 실수를 방지하는 검증 로직을 적용했습니다.

---
  

### ✅ 작업 내용
- [x] 기능 개발
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

### 🧪 테스트 내용
#### **1. 테이블 예약 시간대 목록 조회**
> `GET /api/v1/stores/{storeId}/tables/{tableId}/slots`
* **테스트 포인트**: 영업시간 내 슬롯 생성 여부 및 필터링(예약, 브레이크 타임) 정상 작동 확인

<img width="1406" height="734" alt="목록 조회 테스트 1" src="https://github.com/user-attachments/assets/507bd4f3-cb61-4f3e-89f9-0f4603543e48" />
<img width="1400" height="636" alt="목록 조회 테스트 2" src="https://github.com/user-attachments/assets/14bfdd86-b060-4830-8df2-c2f2cfe48bd0" />

---

#### **2. 테이블 슬롯 상태 변경**
> `PATCH /api/v1/stores/{storeId}/tables/{tableId}/slots`
* **테스트 포인트**: 미운영(Block) 전환 및 부적절한 상태 변경 시 예외 처리 확인

<img width="1397" height="703" alt="상태 변경 테스트 1" src="https://github.com/user-attachments/assets/b74fc242-0966-48e7-8fee-2a740ca169c4" />
<img width="1402" height="601" alt="상태 변경 테스트 2" src="https://github.com/user-attachments/assets/cb2276b3-9f4c-4d1f-ade1-61b46f007b65" />
<img width="1174" height="475" alt="예외 처리 테스트" src="https://github.com/user-attachments/assets/88b1cca2-35e5-415b-b60d-b380d8da589e" />

---

### 📝 기타 참고 사항
- Closes #63
