### PR TITLE
[FIX]: 배포 워크플로우 main으로 변경

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,5 +34,5 @@ jobs:
         run: chmod +x gradlew
         shell: bash
 
-      - name: Test (테스트)
-        run: ./gradlew build
+      - name: Build & Test
+        run: ./gradlew clean build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,6 @@ name: Deploy
 on:
   push:
     branches:
-      - develop
       - main
 
 jobs:
@@ -43,7 +42,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: 도커 이미지 빌드
-        run: docker build --platform linux/amd64 -t ${{ secrets.DOCKERHUB_USERNAME }}/eatsfine-be .
+        run: docker build --platform linux/amd64 -t ${{ secrets.DOCKERHUB_USERNAME }}/eatsfine-be:latest .
 
       - name: 도커 이미지 푸시
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/eatsfine-be:latest


### PR DESCRIPTION
### 💡 작업 개요
- ci는 main, develop 브랜치에서 진행하고, cd는 main 브랜치로만 배포되게 진행합니다.

### ✅ 작업 내용
- [ ] 기능 개발
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정