### PR TITLE
[CHORE]: 불필요 도커 이미지 및 컨테이너 정리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: EC2 배포
         run: |
-          ssh eatsfine-ec2 << 'EOF'
+          ssh eatsfine-ec2 << EOF
             set -e
             cd /home/ec2-user/deploy
           
@@ -86,6 +86,10 @@ jobs:
           
             docker compose down
             docker compose up -d
+          
+            # 불필요한 도커 이미지 및 컨테이너 정리
+            docker image prune -f
+            docker container prune -f
           
             docker ps
           EOF


### PR DESCRIPTION
### 💡 작업 개요
- 안쓰는 도커이미지들이 쌓여있어서 cpu 사용률이 확 높아져서 ec2가 먹통이 되는 현상이 발생했었습니다. 불필요 도커 이미지 및 컨테이너 정리했습니다.

### ✅ 작업 내용
- [ ] 기능 개발
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 주석/포맷 정리
- [x] 기타 설정

### 📝 기타 참고 사항
- EC2 배포 환경에서 불필요한 Docker 이미지(<none>)가 다수 누적되어 디스크/리소스 사용량이 증가하는 문제가 있었습니다.
- 배포 스크립트에 docker image prune / docker container prune 정리 작업을 추가하여 불필요 리소스를 제거했습니다.
- 정리 후 서버 리소스 상태가 안정화되었습니다.

