### PR TITLE
[FEAT]: 가게 테이블 상세 조회/수정/삭제 API 구현

### DIFF
--- a/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
@@ -34,4 +34,12 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
             "AND b.bookingTime = :time " +
             "AND b.status IN ('CONFIRMED', 'PENDING')")
     boolean existsBookingByTableAndDateTime(@Param("tableId") Long tableId, @Param("date") LocalDate date, @Param("time") LocalTime time);
+
+    @Query("SELECT COUNT(bt) > 0 FROM BookingTable bt " +
+            "JOIN bt.booking b " +
+            "WHERE bt.storeTable.id = :tableId " +
+            "AND (b.bookingDate > :currentDate " +
+            "     OR (b.bookingDate = :currentDate AND b.bookingTime >= :currentTime)) " +
+            "AND b.status IN ('CONFIRMED', 'PENDING')")
+    boolean existsFutureBookingByTable(@Param("tableId") Long tableId, @Param("currentDate") LocalDate currentDate, @Param("currentTime") LocalTime currentTime);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
@@ -7,6 +7,7 @@ import com.eatsfine.eatsfine.domain.storetable.service.StoreTableCommandService;
 import com.eatsfine.eatsfine.domain.storetable.service.StoreTableQueryService;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
@@ -47,5 +48,14 @@ public class StoreTableController implements StoreTableControllerDocs {
     ) {
         LocalDate targetDate = (date != null) ? date : LocalDate.now();
         return ApiResponse.of(StoreTableSuccessStatus._TABLE_DETAIL_FOUND, storeTableQueryService.getTableDetail(storeId, tableId, targetDate));
+    }
+
+    @PatchMapping("/stores/{storeId}/tables/{tableId}")
+    public ApiResponse<StoreTableResDto.TableUpdateResultDto> updateTable(
+            @PathVariable Long storeId,
+            @PathVariable Long tableId,
+            @RequestBody @Valid StoreTableReqDto.TableUpdateDto dto
+    ) {
+        return ApiResponse.of(StoreTableSuccessStatus._TABLE_UPDATED, storeTableCommandService.updateTable(storeId, tableId, dto));
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
@@ -58,4 +58,12 @@ public class StoreTableController implements StoreTableControllerDocs {
     ) {
         return ApiResponse.of(StoreTableSuccessStatus._TABLE_UPDATED, storeTableCommandService.updateTable(storeId, tableId, dto));
     }
+
+    @DeleteMapping("/stores/{storeId}/tables/{tableId}")
+    public ApiResponse<StoreTableResDto.TableDeleteDto> deleteTable(
+            @PathVariable Long storeId,
+            @PathVariable Long tableId
+    ) {
+        return ApiResponse.of(StoreTableSuccessStatus._TABLE_DELETED, storeTableCommandService.deleteTable(storeId, tableId));
+    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
@@ -38,4 +38,14 @@ public class StoreTableController implements StoreTableControllerDocs {
         LocalDate targetDate = (date != null) ? date : LocalDate.now();
         return ApiResponse.of(StoreTableSuccessStatus._SLOT_LIST_FOUND, storeTableQueryService.getTableSlots(storeId, tableId, targetDate));
     }
+
+    @GetMapping("/stores/{storeId}/tables/{tableId}")
+    public ApiResponse<StoreTableResDto.TableDetailDto> getTableDetail(
+            @PathVariable Long storeId,
+            @PathVariable Long tableId,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
+    ) {
+        LocalDate targetDate = (date != null) ? date : LocalDate.now();
+        return ApiResponse.of(StoreTableSuccessStatus._TABLE_DETAIL_FOUND, storeTableQueryService.getTableDetail(storeId, tableId, targetDate));
+    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
@@ -163,4 +163,28 @@ public interface StoreTableControllerDocs {
 
             @RequestBody @Valid StoreTableReqDto.TableUpdateDto dto
     );
+
+    @Operation(
+            summary = "테이블 삭제",
+            description = """
+                      특정 가게의 테이블을 삭제합니다.
+  
+                      **삭제 조건:**
+                      - 현재 시간 이후의 예약(CONFIRMED 또는 PENDING 상태)이 존재하는 테이블은 삭제할 수 없습니다.
+                      - Soft Delete 방식으로 처리되어 실제 데이터는 삭제되지 않고 is_deleted 플래그가 true로 변경됩니다.
+                      - deleted_at 필드에 삭제 시간이 기록됩니다.
+                      - 삭제된 테이블 위치에 새 테이블 생성 시, 겹침 검증 로직에서 삭제된 테이블은 제외됩니다.
+                      """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "테이블 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "테이블에 미래 예약이 존재함"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "테이블 또는 가게를 찾을 수 없음")
+    })
+    ApiResponse<StoreTableResDto.TableDeleteDto> deleteTable(
+            @Parameter(description = "가게 ID", required = true, example = "1")
+            Long storeId,
+            @Parameter(description = "테이블 ID", required = true, example = "1")
+            Long tableId
+    );
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
@@ -93,4 +93,74 @@ public interface StoreTableControllerDocs {
             @Parameter(description = "조회 날짜 (yyyy-MM-dd)", example = "2026-01-23")
             LocalDate date
     );
+
+    @Operation(
+            summary = "테이블 정보 수정",
+            description = """
+                      특정 테이블의 정보를 수정합니다.
+                      
+                      **통합 API**: 테이블 번호, 좌석 수, 테이블 유형을 하나의 API에서 처리합니다.
+                      
+                      - **선택적 업데이트**: 모든 필드가 Optional이며, 제공된 필드만 업데이트됩니다.
+                      - **최소 하나 필수**: 최소 하나 이상의 필드는 반드시 제공되어야 합니다.
+                      
+                      1. **테이블 번호 (tableNumber)**:
+                         - 숫자 문자열로 전달 (예: "3")
+                         - 자동으로 "N번 테이블" 형식으로 변환
+                         - 중복 시 기존 테이블과 번호 스왑
+                      
+                      2. **좌석 수 (minSeatCount, maxSeatCount)**:
+                         - 둘 중 하나만 제공 시, 다른 값은 기존 값 유지
+                         - 최소 인원 ≤ 최대 인원 검증
+                      
+                      3. **테이블 유형 (seatsType)**:
+                         - GENERAL, WINDOW, ROOM, BAR, OUTDOOR 중 선택
+                      
+                      ### 응답:
+                      - updatedTables: 변경된 테이블 정보만 표시
+                      - 번호 스왑 발생 시 두 테이블 모두 포함
+                      - 스왑 없을 시 요청 테이블만 포함
+                      
+                      ### 예시:
+                      ```json
+                      // Request (모든 필드 수정)
+                      {
+                        "tableNumber": "5",
+                        "minSeatCount": 2,
+                        "maxSeatCount": 4,
+                        "seatsType": "ROOM"
+                      }
+                      
+                      // Request (번호만 수정)
+                      {
+                        "tableNumber": "3"
+                      }
+                      
+                      // Request (좌석 수만 수정)
+                      {
+                        "minSeatCount": 4,
+                        "maxSeatCount": 6
+                      }
+                      
+                      // Request (좌석 유형만 수정)
+                      {
+                        "seatsType": "WINDOW"
+                      }
+                      ```
+                      """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "테이블 수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (수정 필드 없음, 좌석 범위 오류 등)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "가게 또는 테이블을 찾을 수 없음")
+    })
+    ApiResponse<StoreTableResDto.TableUpdateResultDto> updateTable(
+            @Parameter(description = "가게 ID", required = true, example = "1")
+            Long storeId,
+
+            @Parameter(description = "테이블 ID", required = true, example = "1")
+            Long tableId,
+
+            @RequestBody @Valid StoreTableReqDto.TableUpdateDto dto
+    );
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
@@ -68,4 +68,29 @@ public interface StoreTableControllerDocs {
             @Parameter(description = "조회할 날짜 (yyyy-MM-dd 형식, 미입력 시 오늘 날짜)", example = "2026-01-12")
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
     );
+
+    @Operation(
+            summary = "테이블 상세 조회",
+            description = """                                                                                          
+                  특정 테이블의 상세 정보를 조회합니다.
+                  - 테이블 기본 정보 (최소/최대 인원, 이미지, 평점, 리뷰 수, 테이블 유형)
+                  - 예약 가능 상태 (날짜별 총 슬롯 수, 예약 가능한 슬롯 수)
+                  - date 파라미터가 없으면 오늘 날짜로 조회합니다.
+                  """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "테이블 상세 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "테이블이 가게에 속하지 않음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "테이블을 찾을 수 없음")
+    })
+    ApiResponse<StoreTableResDto.TableDetailDto> getTableDetail(
+            @Parameter(description = "가게 ID", required = true, example = "1")
+            Long storeId,
+
+            @Parameter(description = "테이블 ID", required = true, example = "1")
+            Long tableId,
+
+            @Parameter(description = "조회 날짜 (yyyy-MM-dd)", example = "2026-01-23")
+            LocalDate date
+    );
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
@@ -4,6 +4,7 @@ import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
 import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
 import com.eatsfine.eatsfine.domain.storetable.util.SlotCalculator;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class StoreTableConverter {
@@ -38,6 +39,25 @@ public class StoreTableConverter {
                 .totalSlotCount(totalCount)
                 .availableSlotCount(availableCount)
                 .slots(slotDetails)
+                .build();
+    }
+
+    public static StoreTableResDto.TableDetailDto toTableDetailDto(StoreTable table, LocalDate targetDate, int totalSlotCount, int availableSlotCount) {
+        return StoreTableResDto.TableDetailDto.builder()
+                .tableId(table.getId())
+                .minSeatCount(table.getMinSeatCount())
+                .maxSeatCount(table.getMaxSeatCount())
+                .tableImageUrl(table.getTableImageUrl())
+                .rating(table.getRating())
+                .reviewCount(0) // 리뷰 기능 미구현으로 0 반환
+                .seatsType(table.getSeatsType())
+                .reservationStatus(
+                        StoreTableResDto.ReservationStatusDto.builder()
+                                .targetDate(targetDate)
+                                .totalSlotCount(totalSlotCount)
+                                .availableSlotCount(availableSlotCount)
+                                .build()
+                )
                 .build();
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
@@ -1,5 +1,6 @@
 package com.eatsfine.eatsfine.domain.storetable.converter;
 
+import com.eatsfine.eatsfine.domain.storetable.dto.req.StoreTableReqDto;
 import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
 import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
 import com.eatsfine.eatsfine.domain.storetable.util.SlotCalculator;
@@ -58,6 +59,33 @@ public class StoreTableConverter {
                                 .availableSlotCount(availableSlotCount)
                                 .build()
                 )
+                .build();
+    }
+
+    public static StoreTableResDto.TableUpdateResultDto toTableUpdateResultDto(List<StoreTable> updatedTables, StoreTableReqDto.TableUpdateDto requestDto) {
+        List<StoreTableResDto.UpdatedTableDto> updatedTableDtoList = updatedTables.stream()
+                .map(table -> {
+                    var builder = StoreTableResDto.UpdatedTableDto.builder()
+                            .tableId(table.getId()); // tableId는 항상 포함
+
+                    // 요청 DTO에 있는 필드만 응답에 포함
+                    if (requestDto.tableNumber() != null) {
+                        builder.tableNumber(table.getTableNumber());
+                    }
+                    if (requestDto.minSeatCount() != null || requestDto.maxSeatCount() != null) {
+                        builder.minSeatCount(table.getMinSeatCount());
+                        builder.maxSeatCount(table.getMaxSeatCount());
+                    }
+                    if (requestDto.seatsType() != null) {
+                        builder.seatsType(table.getSeatsType());
+                    }
+
+                    return builder.build();
+                })
+                .toList();
+
+        return StoreTableResDto.TableUpdateResultDto.builder()
+                .updatedTables(updatedTableDtoList)
                 .build();
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
@@ -88,4 +88,10 @@ public class StoreTableConverter {
                 .updatedTables(updatedTableDtoList)
                 .build();
     }
+
+    public static StoreTableResDto.TableDeleteDto toTableDeleteDto(StoreTable table) {
+        return StoreTableResDto.TableDeleteDto.builder()
+                .tableId(table.getId())
+                .build();
+    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/req/StoreTableReqDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/req/StoreTableReqDto.java
@@ -4,6 +4,7 @@ import com.eatsfine.eatsfine.domain.storetable.enums.SeatsType;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 public class StoreTableReqDto {
     public record TableCreateDto(
@@ -30,4 +31,25 @@ public class StoreTableReqDto {
 
             String tableImageUrl
     ) {}
+
+    public record TableUpdateDto(
+            @Pattern(regexp = "^[1-9]\\d*$", message = "테이블 번호는 1 이상의 숫자여야 합니다.")
+            String tableNumber,
+
+            @Min(value = 1, message = "최소 인원은 1명 이상이어야 합니다.")
+            @Max(value = 20, message = "최소 인원은 20명 이하여야 합니다.")
+            Integer minSeatCount,
+
+            @Min(value = 1, message = "최대 인원은 1명 이상이어야 합니다.")
+            @Max(value = 20, message = "최대 인원은 20명 이하여야 합니다.")
+            Integer maxSeatCount,
+
+            SeatsType seatsType
+    ) {
+        // 최소 하나의 필드는 있어야 함
+        public boolean hasAnyUpdate() {
+            return tableNumber != null || minSeatCount != null
+                    || maxSeatCount != null || seatsType != null;
+        }
+    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
@@ -3,6 +3,7 @@ package com.eatsfine.eatsfine.domain.storetable.dto.res;
 import com.eatsfine.eatsfine.domain.storetable.enums.SeatsType;
 import com.eatsfine.eatsfine.domain.tableblock.enums.SlotStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 import java.math.BigDecimal;
@@ -60,5 +61,20 @@ public class StoreTableResDto {
             LocalDate targetDate,
             Integer totalSlotCount,
             Integer availableSlotCount
+    ) {}
+
+    @Builder
+    public record TableUpdateResultDto(
+            List<UpdatedTableDto> updatedTables
+    ) {}
+
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record UpdatedTableDto(
+            Long tableId,
+            String tableNumber,
+            Integer minSeatCount,
+            Integer maxSeatCount,
+            SeatsType seatsType
     ) {}
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
@@ -77,4 +77,9 @@ public class StoreTableResDto {
             Integer maxSeatCount,
             SeatsType seatsType
     ) {}
+
+    @Builder
+    public record TableDeleteDto(
+            Long tableId
+    ) {}
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -39,5 +40,25 @@ public class StoreTableResDto {
             LocalTime time,
             SlotStatus status,
             boolean isAvailable
+    ) {}
+
+    @Builder
+    public record TableDetailDto(
+            Long tableId,
+            Integer minSeatCount,
+            Integer maxSeatCount,
+            String tableImageUrl,
+            BigDecimal rating,
+            Integer reviewCount,
+            SeatsType seatsType,
+            ReservationStatusDto reservationStatus
+    ) {}
+
+    @Builder
+    public record ReservationStatusDto(
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+            LocalDate targetDate,
+            Integer totalSlotCount,
+            Integer availableSlotCount
     ) {}
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/entity/StoreTable.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/entity/StoreTable.java
@@ -1,6 +1,5 @@
 package com.eatsfine.eatsfine.domain.storetable.entity;
 
-import com.eatsfine.eatsfine.domain.store.entity.Store;
 import com.eatsfine.eatsfine.domain.storetable.enums.SeatsType;
 import com.eatsfine.eatsfine.domain.table_layout.entity.TableLayout;
 import com.eatsfine.eatsfine.global.entity.BaseEntity;
@@ -70,4 +69,20 @@ public class StoreTable extends BaseEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    // 테이블 번호 변경
+    public void updateTableNumber(String tableNumber) {
+        this.tableNumber = tableNumber;
+    }
+
+    // 테이블 좌석 수 변경
+    public void updateSeatCount(int minSeatCount, int maxSeatCount) {
+        this.minSeatCount = minSeatCount;
+        this.maxSeatCount = maxSeatCount;
+    }
+
+    // 테이블 유형 변경
+    public void updateSeatsType(SeatsType seatsType) {
+        this.seatsType = seatsType;
+    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableErrorStatus.java
@@ -19,6 +19,7 @@ public enum StoreTableErrorStatus implements BaseErrorCode {
     _NO_UPDATE_FIELD(HttpStatus.BAD_REQUEST, "TABLE400_5", "수정할 필드가 최소 하나 이상 필요합니다."),
     _SAME_SEAT_COUNT(HttpStatus.BAD_REQUEST, "TABLE400_6", "기존 좌석 수와 동일합니다."),
     _SAME_SEATS_TYPE(HttpStatus.BAD_REQUEST, "TABLE400_7", "기존 좌석 유형과 동일합니다."),
+    _TABLE_HAS_FUTURE_BOOKING(HttpStatus.BAD_REQUEST, "TABLE400_8", "해당 테이블에 존재하는 예약이 있어 삭제할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableErrorStatus.java
@@ -16,6 +16,9 @@ public enum StoreTableErrorStatus implements BaseErrorCode {
     _TABLE_POSITION_OVERLAPS(HttpStatus.BAD_REQUEST, "TABLE400_3", "해당 위치에 이미 다른 테이블이 존재합니다."),
     _TABLE_NOT_BELONGS_TO_STORE(HttpStatus.BAD_REQUEST, "TABLE400_4", "해당 테이블은 해당 가게에 속하지 않습니다."),
     _NO_BUSINESS_HOURS(HttpStatus.NOT_FOUND, "TABLE404_2", "해당 요일의 영업시간 정보를 찾을 수 없습니다."),
+    _NO_UPDATE_FIELD(HttpStatus.BAD_REQUEST, "TABLE400_5", "수정할 필드가 최소 하나 이상 필요합니다."),
+    _SAME_SEAT_COUNT(HttpStatus.BAD_REQUEST, "TABLE400_6", "기존 좌석 수와 동일합니다."),
+    _SAME_SEATS_TYPE(HttpStatus.BAD_REQUEST, "TABLE400_7", "기존 좌석 유형과 동일합니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableSuccessStatus.java
@@ -13,6 +13,7 @@ public enum StoreTableSuccessStatus implements BaseCode {
     _TABLE_CREATED(HttpStatus.CREATED, "TABLE201_1", "성공적으로 테이블을 생성했습니다."),
     _SLOT_LIST_FOUND(HttpStatus.OK, "TABLE200_1", "테이블 시간 슬롯 조회에 성공했습니다."),
     _TABLE_DETAIL_FOUND(HttpStatus.OK, "TABLE200_2", "테이블 상세 정보 조회에 성공했습니다."),
+    _TABLE_UPDATED(HttpStatus.OK, "TABLE200_3", "성공적으로 테이블 정보를 수정했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableSuccessStatus.java
@@ -14,6 +14,7 @@ public enum StoreTableSuccessStatus implements BaseCode {
     _SLOT_LIST_FOUND(HttpStatus.OK, "TABLE200_1", "테이블 시간 슬롯 조회에 성공했습니다."),
     _TABLE_DETAIL_FOUND(HttpStatus.OK, "TABLE200_2", "테이블 상세 정보 조회에 성공했습니다."),
     _TABLE_UPDATED(HttpStatus.OK, "TABLE200_3", "성공적으로 테이블 정보를 수정했습니다."),
+    _TABLE_DELETED(HttpStatus.OK, "TABLE200_4", "성공적으로 테이블을 삭제했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/exception/status/StoreTableSuccessStatus.java
@@ -12,6 +12,7 @@ public enum StoreTableSuccessStatus implements BaseCode {
 
     _TABLE_CREATED(HttpStatus.CREATED, "TABLE201_1", "성공적으로 테이블을 생성했습니다."),
     _SLOT_LIST_FOUND(HttpStatus.OK, "TABLE200_1", "테이블 시간 슬롯 조회에 성공했습니다."),
+    _TABLE_DETAIL_FOUND(HttpStatus.OK, "TABLE200_2", "테이블 상세 정보 조회에 성공했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/repository/StoreTableRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/repository/StoreTableRepository.java
@@ -1,6 +1,7 @@
 package com.eatsfine.eatsfine.domain.storetable.repository;
 
 import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
+import com.eatsfine.eatsfine.domain.table_layout.entity.TableLayout;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -8,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StoreTableRepository extends JpaRepository<StoreTable,Long> {
 
@@ -16,4 +18,7 @@ public interface StoreTableRepository extends JpaRepository<StoreTable,Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT st FROM StoreTable st WHERE st.id IN :ids")
     List<StoreTable> findAllByIdWithLock(@Param("ids") List<Long> ids);
+
+    // 특정 레이아웃에서 특정 번호를 가진 활성 테이블 조회, 테이블 번호 중복 체크용
+    Optional<StoreTable> findByTableLayoutAndTableNumberAndIsDeletedFalse(TableLayout tableLayout, String tableNumber);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandService.java
@@ -7,4 +7,6 @@ public interface StoreTableCommandService {
     StoreTableResDto.TableCreateDto createTable(Long storeId, StoreTableReqDto.TableCreateDto dto);
 
     StoreTableResDto.TableUpdateResultDto updateTable(Long storeId, Long tableId, StoreTableReqDto.TableUpdateDto dto);
+
+    StoreTableResDto.TableDeleteDto deleteTable(Long storeId, Long tableId);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandService.java
@@ -5,4 +5,6 @@ import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
 
 public interface StoreTableCommandService {
     StoreTableResDto.TableCreateDto createTable(Long storeId, StoreTableReqDto.TableCreateDto dto);
+
+    StoreTableResDto.TableUpdateResultDto updateTable(Long storeId, Long tableId, StoreTableReqDto.TableUpdateDto dto);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryService.java
@@ -6,4 +6,6 @@ import java.time.LocalDate;
 
 public interface StoreTableQueryService {
     StoreTableResDto.SlotListDto getTableSlots(Long storeId, Long tableId, LocalDate date);
+
+    StoreTableResDto.TableDetailDto getTableDetail(Long storeId, Long tableId, LocalDate targetDate);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryServiceImpl.java
@@ -1,6 +1,9 @@
 package com.eatsfine.eatsfine.domain.storetable.service;
 
 import com.eatsfine.eatsfine.domain.booking.repository.BookingRepository;
+import com.eatsfine.eatsfine.domain.store.exception.StoreException;
+import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
+import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
 import com.eatsfine.eatsfine.domain.storetable.converter.StoreTableConverter;
 import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
 import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
@@ -25,6 +28,7 @@ import java.util.Set;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class StoreTableQueryServiceImpl implements StoreTableQueryService{
+    private final StoreRepository storeRepository;
     private final StoreTableRepository storeTableRepository;
     private final TableBlockRepository tableBlockRepository;
     private final BookingRepository bookingRepository;
@@ -32,6 +36,9 @@ public class StoreTableQueryServiceImpl implements StoreTableQueryService{
     // 테이블 슬롯 조회
     @Override
     public StoreTableResDto.SlotListDto getTableSlots(Long storeId, Long tableId, LocalDate date) {
+        storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+
         StoreTable storeTable = storeTableRepository.findById(tableId)
                 .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._TABLE_NOT_FOUND));
 
@@ -47,6 +54,30 @@ public class StoreTableQueryServiceImpl implements StoreTableQueryService{
                 result.totalSlotCount(),
                 result.availableSlotCount(),
                 result.slots()
+        );
+    }
+
+    @Override
+    public StoreTableResDto.TableDetailDto getTableDetail(Long storeId, Long tableId, LocalDate targetDate) {
+        storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+
+        StoreTable storeTable = storeTableRepository.findById(tableId)
+                .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._TABLE_NOT_FOUND));
+
+        StoreTableValidator.validateTableBelongsToStore(storeTable, storeId);
+
+        List<TableBlock> tableBlocks = tableBlockRepository.findByStoreTableAndTargetDate(storeTable, targetDate);
+        List<LocalTime> bookedTimeList = bookingRepository.findBookedTimesByTableAndDate(tableId, targetDate);
+        Set<LocalTime> bookedTimes = new HashSet<>(bookedTimeList);
+
+        SlotCalculator.SlotCalculationResult result = SlotCalculator.calculateSlots(storeTable, targetDate, tableBlocks, bookedTimes);
+
+        return StoreTableConverter.toTableDetailDto(
+                storeTable,
+                targetDate,
+                result.totalSlotCount(),
+                result.availableSlotCount()
         );
     }
 }


### PR DESCRIPTION
### 💡 작업 개요
#### **1. 테이블 상세 조회 (GET)**
* 특정 테이블의 상세 정보 조회
* 특정 날짜의 예약 가능 시간대 갯수 제공
* 쿼리 파라미터 date로 조회할 날짜 지정 (기본값: 오늘)

#### **2. 테이블 정보 수정 (PATCH)**
* 부분 수정: 테이블 번호, 좌석 수, 테이블 유형을 하나의 API로 통합 처리                            
* 테이블 번호 스왑: 중복된 번호 수정 시 기존 테이블과 번호 교환                                                    
* 응답: 수정된 필드만 응답에 포함 `(@JsonInclude(NON_NULL))`

#### **3. 테이블 삭제 (DELETE)**
* Soft Delete 방식으로 테이블 삭제
* 예약 존재 시 삭제 불가: 현재 시간 이후의 예약(`CONFIRMED/PENDING`)이 있으면 삭제 차단

---

### ✅ 작업 내용
- [x] 기능 개발
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

### 🧪 테스트 내용
#### **1. 테이블 상세 조회**
> `GET /api/v1/stores/{storeId}/tables/{tableId}`
<img width="1405" height="589" alt="스크린샷 2026-01-23 233003" src="https://github.com/user-attachments/assets/778a8536-9aba-451a-8a52-0e9db4fcf537" />

---

#### **2. 테이블 정보 수정**
> `PATCH /api/v1/stores/{storeId}/tables/{tableId}`
* **기존 6번 테이블 -> 2번 테이블로 변경 시**
<img width="1403" height="579" alt="스크린샷 2026-01-26 023014" src="https://github.com/user-attachments/assets/bbab5c8a-55ac-4b33-a26c-dd4c146441e4" />

--- 

* **7번 테이블로 변경 시**
<img width="1402" height="529" alt="스크린샷 2026-01-26 023107" src="https://github.com/user-attachments/assets/7e9279a0-a955-4d42-93ed-dbc357eb3448" />

---

* **테이블 인원 수 변경**
<img width="1403" height="555" alt="스크린샷 2026-01-26 023146" src="https://github.com/user-attachments/assets/110ee671-8b1d-4d36-9364-a384a6d3e283" />
<img width="1404" height="539" alt="스크린샷 2026-01-26 023216" src="https://github.com/user-attachments/assets/9765b96b-ade1-4d47-b496-eb0513fba5cb" />

---

* **테이블 유형 변경**
<img width="1415" height="529" alt="스크린샷 2026-01-26 023250" src="https://github.com/user-attachments/assets/2bff309d-e66c-4b0a-82ab-372eb867196a" />

---

* **모든 속성 변경**
<img width="1401" height="700" alt="스크린샷 2026-01-26 024613" src="https://github.com/user-attachments/assets/12e52c34-555e-413a-abae-0c5b9ed5342c" />

#### **2. 테이블 삭제**
> `DELETE /api/v1/stores/{storeId}/tables/{tableId}`
* **예약 존재 시 결과**
<img width="1395" height="427" alt="스크린샷 2026-01-26 165757" src="https://github.com/user-attachments/assets/415d4b7b-25d5-402c-a02e-fc40e7998853" />

---

* **정상 삭제**
<img width="1398" height="431" alt="스크린샷 2026-01-26 165817" src="https://github.com/user-attachments/assets/478b92f1-04f4-47bf-9cc8-c6c0d910fbaa" />

---

### 📝 기타 참고 사항
- Closes #73


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new table management endpoints: retrieve detailed table information with reservation status, update table properties (table number, seat counts, seat type), and delete tables with safety validation.
  * Implemented validation to prevent deletion of tables with existing or future reservations.
  * Added comprehensive API documentation for new endpoints.

* **Chores**
  * Enhanced repository queries and service methods to support table management operations.
  * Expanded error handling with specific messages for invalid update and deletion scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->