### PR TITLE
가게 개별 테이블 이미지 등록/삭제 API 구현

### DIFF
--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
@@ -5,12 +5,15 @@ import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
 import com.eatsfine.eatsfine.domain.storetable.exception.status.StoreTableSuccessStatus;
 import com.eatsfine.eatsfine.domain.storetable.service.StoreTableCommandService;
 import com.eatsfine.eatsfine.domain.storetable.service.StoreTableQueryService;
+import com.eatsfine.eatsfine.domain.tableimage.status.TableImageSuccessStatus;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 
@@ -65,5 +68,17 @@ public class StoreTableController implements StoreTableControllerDocs {
             @PathVariable Long tableId
     ) {
         return ApiResponse.of(StoreTableSuccessStatus._TABLE_DELETED, storeTableCommandService.deleteTable(storeId, tableId));
+    }
+
+    @PostMapping(
+            value = "/stores/{storeId}/tables/{tableId}/table-image",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ApiResponse<StoreTableResDto.UploadTableImageDto> uploadTableImage(
+            @PathVariable Long storeId,
+            @PathVariable Long tableId,
+            @RequestPart("tableImage") MultipartFile tableImage
+    ) {
+        return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_UPLOAD_SUCCESS, storeTableCommandService.uploadTableImage(storeId, tableId, tableImage));
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
@@ -81,4 +81,12 @@ public class StoreTableController implements StoreTableControllerDocs {
     ) {
         return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_UPLOAD_SUCCESS, storeTableCommandService.uploadTableImage(storeId, tableId, tableImage));
     }
+
+    @DeleteMapping("/stores/{storeId}/tables/{tableId}/table-image")
+    public ApiResponse<StoreTableResDto.DeleteTableImageDto> deleteTableImage(
+            @PathVariable Long storeId,
+            @PathVariable Long tableId
+    ) {
+        return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_DELETE_SUCCESS, storeTableCommandService.deleteTableImage(storeId, tableId));
+    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
@@ -221,4 +221,27 @@ public interface StoreTableControllerDocs {
             )
             MultipartFile tableImage
     );
+
+    @Operation(
+            summary = "테이블 이미지 삭제",
+            description = """
+                특정 테이블의 이미지를 삭제합니다.
+                
+                - 등록된 이미지가 없는 경우 404 에러가 발생합니다.
+                - S3에서 이미지가 삭제되고, DB의 이미지 URL도 null로 업데이트됩니다.
+                - 삭제 후 다시 이미지를 등록할 수 있습니다.
+                """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "테이블 이미지 삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "테이블이 해당 가게에 속하지 않음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "가게, 테이블을 찾을 수 없거나 이미지가 등록되지 않음")
+    })
+    ApiResponse<StoreTableResDto.DeleteTableImageDto> deleteTableImage(
+            @Parameter(description = "가게 ID", required = true, example = "1")
+            Long storeId,
+
+            @Parameter(description = "테이블 ID", required = true, example = "1")
+            Long tableId
+    );
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
@@ -5,11 +5,14 @@ import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 
@@ -186,5 +189,36 @@ public interface StoreTableControllerDocs {
             Long storeId,
             @Parameter(description = "테이블 ID", required = true, example = "1")
             Long tableId
+    );
+
+    @Operation(
+            summary = "테이블 이미지 등록",
+            description = """
+            특정 테이블의 이미지를 등록합니다.
+            
+            - 테이블당 1개의 이미지만 등록 가능합니다.
+            - 기존 이미지가 있는 경우 자동으로 삭제되고 새 이미지로 교체됩니다.
+            - S3 저장 경로: stores/{storeId}/tables/{tableId}/
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "테이블 이미지 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (빈 파일, 지원하지 않는 파일 형식 등)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "가게 또는 테이블을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "S3 업로드 실패")
+    })
+    ApiResponse<StoreTableResDto.UploadTableImageDto> uploadTableImage(
+            @Parameter(description = "가게 ID", required = true, example = "1")
+            Long storeId,
+
+            @Parameter(description = "테이블 ID", required = true, example = "1")
+            Long tableId,
+
+            @Parameter(
+                    description = "업로드할 테이블 이미지 파일",
+                    required = true,
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
+            )
+            MultipartFile tableImage
     );
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
@@ -101,4 +101,10 @@ public class StoreTableConverter {
                 .tableImageUrl(tableImageUrl)
                 .build();
     }
+
+    public static StoreTableResDto.DeleteTableImageDto toDeleteTableImageDto(Long tableId) {
+        return StoreTableResDto.DeleteTableImageDto.builder()
+                .tableId(tableId)
+                .build();
+    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
@@ -43,12 +43,12 @@ public class StoreTableConverter {
                 .build();
     }
 
-    public static StoreTableResDto.TableDetailDto toTableDetailDto(StoreTable table, LocalDate targetDate, int totalSlotCount, int availableSlotCount) {
+    public static StoreTableResDto.TableDetailDto toTableDetailDto(StoreTable table, LocalDate targetDate, int totalSlotCount, int availableSlotCount, String tableImageUrl) {
         return StoreTableResDto.TableDetailDto.builder()
                 .tableId(table.getId())
                 .minSeatCount(table.getMinSeatCount())
                 .maxSeatCount(table.getMaxSeatCount())
-                .tableImageUrl(table.getTableImageUrl())
+                .tableImageUrl(tableImageUrl)
                 .rating(table.getRating())
                 .reviewCount(0) // 리뷰 기능 미구현으로 0 반환
                 .seatsType(table.getSeatsType())

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
@@ -94,4 +94,11 @@ public class StoreTableConverter {
                 .tableId(table.getId())
                 .build();
     }
+
+    public static StoreTableResDto.UploadTableImageDto toUploadTableImageDto(Long tableId, String tableImageUrl) {
+        return StoreTableResDto.UploadTableImageDto.builder()
+                .tableId(tableId)
+                .tableImageUrl(tableImageUrl)
+                .build();
+    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
@@ -82,4 +82,10 @@ public class StoreTableResDto {
     public record TableDeleteDto(
             Long tableId
     ) {}
+
+    @Builder
+    public record UploadTableImageDto(
+            Long tableId,
+            String tableImageUrl
+    ) {}
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
@@ -88,4 +88,9 @@ public class StoreTableResDto {
             Long tableId,
             String tableImageUrl
     ) {}
+
+    @Builder
+    public record DeleteTableImageDto(
+            Long tableId
+    ) {}
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/entity/StoreTable.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/entity/StoreTable.java
@@ -90,4 +90,9 @@ public class StoreTable extends BaseEntity {
     public void updateTableImage(String imageKey) {
         this.tableImageUrl = imageKey;
     }
+
+    // 테이블 이미지 삭제
+    public void deleteTableImage() {
+        this.tableImageUrl = null;
+    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/entity/StoreTable.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/entity/StoreTable.java
@@ -85,4 +85,9 @@ public class StoreTable extends BaseEntity {
     public void updateSeatsType(SeatsType seatsType) {
         this.seatsType = seatsType;
     }
+
+    // 테이블 이미지 업로드
+    public void updateTableImage(String imageKey) {
+        this.tableImageUrl = imageKey;
+    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandService.java
@@ -12,4 +12,6 @@ public interface StoreTableCommandService {
     StoreTableResDto.TableDeleteDto deleteTable(Long storeId, Long tableId);
 
     StoreTableResDto.UploadTableImageDto uploadTableImage(Long storeId, Long tableId, MultipartFile tableImage);
+
+    StoreTableResDto.DeleteTableImageDto deleteTableImage(Long storeId, Long tableId);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandService.java
@@ -2,6 +2,7 @@ package com.eatsfine.eatsfine.domain.storetable.service;
 
 import com.eatsfine.eatsfine.domain.storetable.dto.req.StoreTableReqDto;
 import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface StoreTableCommandService {
     StoreTableResDto.TableCreateDto createTable(Long storeId, StoreTableReqDto.TableCreateDto dto);
@@ -9,4 +10,6 @@ public interface StoreTableCommandService {
     StoreTableResDto.TableUpdateResultDto updateTable(Long storeId, Long tableId, StoreTableReqDto.TableUpdateDto dto);
 
     StoreTableResDto.TableDeleteDto deleteTable(Long storeId, Long tableId);
+
+    StoreTableResDto.UploadTableImageDto uploadTableImage(Long storeId, Long tableId, MultipartFile tableImage);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandServiceImpl.java
@@ -195,6 +195,28 @@ public class StoreTableCommandServiceImpl implements StoreTableCommandService {
         return StoreTableConverter.toUploadTableImageDto(tableId, tableImageUrl);
     }
 
+    @Override
+    public StoreTableResDto.DeleteTableImageDto deleteTableImage(Long storeId, Long tableId) {
+        storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+
+        StoreTable table = storeTableRepository.findById(tableId)
+                .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._TABLE_NOT_FOUND));
+
+        StoreTableValidator.validateTableBelongsToStore(table, storeId);
+
+        // 이미지가 존재하는지 확인
+        if (table.getTableImageUrl() == null || table.getTableImageUrl().isBlank()) {
+            throw new ImageException(ImageErrorStatus._IMAGE_NOT_FOUND);
+        }
+
+        s3Service.deleteByKey(table.getTableImageUrl());
+
+        table.deleteTableImage();
+
+        return StoreTableConverter.toDeleteTableImageDto(tableId);
+    }
+
     private String generateTableNumber(TableLayout layout) {
         List<StoreTable> tables = layout.getTables();
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandServiceImpl.java
@@ -1,6 +1,8 @@
 package com.eatsfine.eatsfine.domain.storetable.service;
 
 import com.eatsfine.eatsfine.domain.booking.repository.BookingRepository;
+import com.eatsfine.eatsfine.domain.image.exception.ImageException;
+import com.eatsfine.eatsfine.domain.image.status.ImageErrorStatus;
 import com.eatsfine.eatsfine.domain.store.exception.StoreException;
 import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
 import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
@@ -16,9 +18,11 @@ import com.eatsfine.eatsfine.domain.table_layout.entity.TableLayout;
 import com.eatsfine.eatsfine.domain.table_layout.exception.TableLayoutException;
 import com.eatsfine.eatsfine.domain.table_layout.exception.status.TableLayoutErrorStatus;
 import com.eatsfine.eatsfine.domain.table_layout.repository.TableLayoutRepository;
+import com.eatsfine.eatsfine.global.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -35,6 +39,7 @@ public class StoreTableCommandServiceImpl implements StoreTableCommandService {
     private final TableLayoutRepository tableLayoutRepository;
     private final StoreTableRepository storeTableRepository;
     private final BookingRepository bookingRepository;
+    private final S3Service s3Service;
 
     // 테이블 생성
     @Override
@@ -158,6 +163,36 @@ public class StoreTableCommandServiceImpl implements StoreTableCommandService {
         storeTableRepository.delete(table);
 
         return StoreTableConverter.toTableDeleteDto(table);
+    }
+
+    // 테이블 이미지 업로드
+    @Override
+    public StoreTableResDto.UploadTableImageDto uploadTableImage(Long storeId, Long tableId, MultipartFile tableImage) {
+        storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+
+        StoreTable table = storeTableRepository.findById(tableId)
+                .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._TABLE_NOT_FOUND));
+
+        StoreTableValidator.validateTableBelongsToStore(table, storeId);
+
+        if (tableImage == null || tableImage.isEmpty()) {
+            throw new ImageException(ImageErrorStatus.EMPTY_FILE);
+        }
+
+        // 기존 이미지가 존재할 경우 삭제
+        if (table.getTableImageUrl() != null && !table.getTableImageUrl().isBlank()) {
+            s3Service.deleteByKey(table.getTableImageUrl());
+        }
+
+        String key = s3Service.upload(tableImage, "stores/" + storeId + "/tables/" + tableId);
+
+        table.updateTableImage(key);
+
+        // URL 변환 및 응답
+        String tableImageUrl = s3Service.toUrl(key);
+
+        return StoreTableConverter.toUploadTableImageDto(tableId, tableImageUrl);
     }
 
     private String generateTableNumber(TableLayout layout) {

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryServiceImpl.java
@@ -14,6 +14,7 @@ import com.eatsfine.eatsfine.domain.storetable.util.SlotCalculator;
 import com.eatsfine.eatsfine.domain.storetable.validator.StoreTableValidator;
 import com.eatsfine.eatsfine.domain.tableblock.entity.TableBlock;
 import com.eatsfine.eatsfine.domain.tableblock.repository.TableBlockRepository;
+import com.eatsfine.eatsfine.global.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +33,7 @@ public class StoreTableQueryServiceImpl implements StoreTableQueryService{
     private final StoreTableRepository storeTableRepository;
     private final TableBlockRepository tableBlockRepository;
     private final BookingRepository bookingRepository;
+    private final S3Service s3Service;
 
     // 테이블 슬롯 조회
     @Override
@@ -57,6 +59,7 @@ public class StoreTableQueryServiceImpl implements StoreTableQueryService{
         );
     }
 
+    // 테이블 상세 조회
     @Override
     public StoreTableResDto.TableDetailDto getTableDetail(Long storeId, Long tableId, LocalDate targetDate) {
         storeRepository.findById(storeId)
@@ -73,11 +76,15 @@ public class StoreTableQueryServiceImpl implements StoreTableQueryService{
 
         SlotCalculator.SlotCalculationResult result = SlotCalculator.calculateSlots(storeTable, targetDate, tableBlocks, bookedTimes);
 
+        // S3 Key -> Url 변환
+        String tableImageUrl = s3Service.toUrl(storeTable.getTableImageUrl());
+
         return StoreTableConverter.toTableDetailDto(
                 storeTable,
                 targetDate,
                 result.totalSlotCount(),
-                result.availableSlotCount()
+                result.availableSlotCount(),
+                tableImageUrl
         );
     }
 }


### PR DESCRIPTION
### 💡 작업 개요
#### **1. S3 저장 경로**
`stores/{storeId}/tables/{tableId}/`

#### **2. 테이블 이미지 등록 (POST)**
* `POST /api/v1/stores/{storeId}/tables/{tableId}/image`
* 테이블 이미지를 AWS S3에 업로드
* 기존에 이미지가 존재할 경우 삭제 후 새로운 이미지 등록
* 응답 DTO 반환 시 S3 Key -> URL로 변환

#### **3. 테이블 이미지 삭제 (DELETE)**
* `DELETE /api/v1/stores/{storeId}/tables/{tableId}/image`
* 서비스 로직에서 이미지가 존재하는지 확인 후 삭제
* Soft delete가 아닌 Hard delete

#### **4. 테이블 상세 조회 시 테이블 이미지 URL 반환 (REFACTOR)**
* Entity에는 S3 Key만 저장되어 있음
* 따라서 null 아니면 S3 Key를 반환
* 서비스 로직에서 S3 Key -> URL 반환하도록 개선

### ✅ 작업 내용
- [x] 기능 개발
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

### 🧪 테스트 내용
* 로컬 환경에서 빌드 정상 실행 확인
* API 테스트는 CD 후 배포 서버에서 Swagger 기반으로 진행 예정

### 📝 기타 참고 사항
- Closes #79


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table image uploads: Store owners can now upload images for individual dining tables, allowing customers to view table details before booking
  * Image management: Delete existing table images and upload replacements to keep content current
  * Enhanced table presentation: Images are automatically stored and retrieved with table information

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->