### PR TITLE
[REFACTOR]: 가게 테이블 생성 시 이미지 업로드 로직 추가

### DIFF
--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
@@ -35,6 +35,14 @@ public class StoreTableController implements StoreTableControllerDocs {
         return ApiResponse.of(StoreTableSuccessStatus._TABLE_CREATED, storeTableCommandService.createTable(storeId, dto));
     }
 
+    @PostMapping(value = "/stores/{storeId}/tables/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<StoreTableResDto.ImageUploadDto> uploadTableImageTemp(
+            @PathVariable Long storeId,
+            @RequestPart("image") MultipartFile file
+    ) {
+        return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_UPLOAD_SUCCESS, storeTableCommandService.uploadTableImageTemp(storeId, file));
+    }
+
     @GetMapping("/stores/{storeId}/tables/{tableId}/slots")
     public ApiResponse<StoreTableResDto.SlotListDto> getTableSlots(
             @PathVariable Long storeId,

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
@@ -44,6 +44,34 @@ public interface StoreTableControllerDocs {
     );
 
     @Operation(
+            summary = "테이블 이미지 선 업로드",
+            description = """
+                테이블 생성 전에 이미지를 먼저 업로드하고 KEY를 반환합니다.
+                
+                - 이미지를 임시 경로(temp/tables/)에 저장합니다.
+                - 반환된 imageKey를 테이블 생성 시 사용합니다.
+                - imageUrl은 프론트엔드에서 즉시 미리보기에 사용할 수 있습니다.
+                - 테이블 생성 시 영구 경로(stores/{storeId}/tables/{tableId}/)로 자동 이동됩니다.
+                """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "이미지 업로드 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (빈 파일, 지원하지 않는 형식 등)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "가게를 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "S3 업로드 실패")
+    })
+    ApiResponse<StoreTableResDto.ImageUploadDto> uploadTableImageTemp(
+            @Parameter(description = "가게 ID", required = true, example = "1")
+            Long storeId,
+            @Parameter(
+                    description = "업로드할 이미지 파일",
+                    required = true,
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
+            )
+            MultipartFile file
+    );
+
+    @Operation(
             summary = "테이블 예약 시간대 조회",
             description = """                                                                                      
                         특정 테이블의 예약 가능한 시간대를 조회합니다.

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public class StoreTableConverter {
     // StoreTable Entity를 생성 응답 DTO로 변환
-    public static StoreTableResDto.TableCreateDto toTableCreateDto(StoreTable table) {
+    public static StoreTableResDto.TableCreateDto toTableCreateDto(StoreTable table, String tableImageUrl) {
         return StoreTableResDto.TableCreateDto.builder()
                 .tableId(table.getId())
                 .tableNumber(table.getTableNumber())
@@ -23,7 +23,7 @@ public class StoreTableConverter {
                 .seatsType(table.getSeatsType())
                 .rating(table.getRating())
                 .reviewCount(0) // 리뷰 기능 미구현으로 0 반환
-                .tableImageUrl(table.getTableImageUrl())
+                .tableImageUrl(tableImageUrl)
                 .build();
     }
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/converter/StoreTableConverter.java
@@ -27,6 +27,13 @@ public class StoreTableConverter {
                 .build();
     }
 
+    public static StoreTableResDto.ImageUploadDto toImageUploadDto(String imageKey, String imageUrl) {
+        return StoreTableResDto.ImageUploadDto.builder()
+                .imageKey(imageKey)
+                .imageUrl(imageUrl)
+                .build();
+    }
+
     public static StoreTableResDto.SlotListDto toSlotListDto(int totalCount, int availableCount, List<SlotCalculator.SlotDto> slots) {
         List<StoreTableResDto.SlotDetailDto> slotDetails = slots.stream()
                 .map(slot -> StoreTableResDto.SlotDetailDto.builder()

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/req/StoreTableReqDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/req/StoreTableReqDto.java
@@ -29,7 +29,7 @@ public class StoreTableReqDto {
             @NotNull(message = "테이블 유형은 필수입니다.")
             SeatsType seatsType,
 
-            String tableImageUrl
+            String tableImageKey
     ) {}
 
     public record TableUpdateDto(

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/dto/res/StoreTableResDto.java
@@ -32,6 +32,12 @@ public class StoreTableResDto {
     ) {}
 
     @Builder
+    public record ImageUploadDto(
+            String imageKey,  // 테이블 생성/수정 시 서버에 다시 보낼 키
+            String imageUrl   // 프론트엔드에서 즉시 미리보기를 위한 전체 URL
+    ) {}
+
+    @Builder
     public record SlotListDto(
             int totalSlotCount,
             int availableSlotCount,

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandService.java
@@ -7,6 +7,8 @@ import org.springframework.web.multipart.MultipartFile;
 public interface StoreTableCommandService {
     StoreTableResDto.TableCreateDto createTable(Long storeId, StoreTableReqDto.TableCreateDto dto);
 
+    StoreTableResDto.ImageUploadDto uploadTableImageTemp(Long storeId, MultipartFile file);
+
     StoreTableResDto.TableUpdateResultDto updateTable(Long storeId, Long tableId, StoreTableReqDto.TableUpdateDto dto);
 
     StoreTableResDto.TableDeleteDto deleteTable(Long storeId, Long tableId);

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandServiceImpl.java
@@ -208,6 +208,19 @@ public class StoreTableCommandServiceImpl implements StoreTableCommandService {
             throw new StoreTableException(StoreTableErrorStatus._TABLE_HAS_FUTURE_BOOKING);
         }
 
+        // 이미지가 존재하면, S3 이미지 삭제
+        String imageKey = table.getTableImageUrl();
+
+        if (imageKey != null && !imageKey.isBlank()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            s3Service.deleteByKey(imageKey);
+                        }
+                    }
+            );
+        }
+
         storeTableRepository.delete(table);
 
         return StoreTableConverter.toTableDeleteDto(table);

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandServiceImpl.java
@@ -83,6 +83,22 @@ public class StoreTableCommandServiceImpl implements StoreTableCommandService {
         return StoreTableConverter.toTableCreateDto(savedTable);
     }
 
+    @Override
+    public StoreTableResDto.ImageUploadDto uploadTableImageTemp(Long storeId, MultipartFile file) {
+        storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+
+        if (file.isEmpty()) {
+            throw new ImageException(ImageErrorStatus.EMPTY_FILE);
+        }
+
+        // 임시 경로에 업로드
+        String tempPath = "temp/tables";
+        String imageKey = s3Service.upload(file, tempPath);
+
+        return StoreTableConverter.toImageUploadDto(imageKey, s3Service.toUrl(imageKey));
+    }
+
     // 테이블 정보 수정
     @Override
     public StoreTableResDto.TableUpdateResultDto updateTable(Long storeId, Long tableId, StoreTableReqDto.TableUpdateDto dto) {


### PR DESCRIPTION
### 💡 작업 개요
#### **1. FEAT: 가게 테이블 이미지 선 업로드 (POST)**
* `POST /api/v1/stores/{storeId}/tables/images`
* 사용자가 테이블 생성 시 이미지만 등록하고 중간에 브라우저를 종료하면 고아 이미지가 생기는 문제가 발생
* 따라서 처음 업로드 시 임시 경로에 저장 후, 테이블 생성 시 정상 경로로 파일을 이동

#### **2. REFACTOR: 가게 테이블 생성 (POST)**
* `POST /api/v1/stores/{storeId}/tables`
* 가게 테이블 이미지 S3 저장경로: `stores/{storeId}/tables/{tableId}/`
* `tableId`를 경로에 포함하기 위해 생성한 테이블을 먼저 저장 후, 이미지를 이동하고 경로를 업데이트 하는 방식으로 수정.

#### **3. REFACTOR: 가게 테이블 삭제 (DELETE)**
* `DELETE /api/v1/stores/{storeId}/tables/{tableId}`
* 가게 테이블 삭제 시 S3에 저장된 이미지도 함께 삭제되도록 코드를 수정

### ✅ 작업 내용
- [x] 기능 개발
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

### 🧪 테스트 내용
- 로컬 환경에서 빌드 정상 실행 확인
- API 테스트는 CD 후 배포 서버에서 Swagger 기반으로 진행 예정

### 📝 기타 참고 사항
- Closes #90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added table image upload endpoint for stores, allowing users to upload images and receive image identifiers and URLs for storage and retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->