### PR TITLE
[FEAT]: Spring Security 기반 사장 권한 RBAC 적용

### DIFF
--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/controller/BusinessHoursController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/controller/BusinessHoursController.java
@@ -8,6 +8,7 @@ import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "BusinessHours", description = "영업시간 관련 API")
@@ -23,6 +24,7 @@ public class BusinessHoursController {
             description = "가게의 영업시간을 수정합니다."
     )
     @PatchMapping("/stores/{storeId}/business-hours")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<BusinessHoursResDto.UpdateBusinessHoursDto> updateBusinessHours(
             @PathVariable Long storeId,
             @RequestBody BusinessHoursReqDto.UpdateBusinessHoursDto dto
@@ -38,6 +40,7 @@ public class BusinessHoursController {
             description = "가게의 브레이크타임을 설정합니다."
     )
     @PatchMapping("/stores/{storeId}/break-time")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<BusinessHoursResDto.UpdateBreakTimeDto> updateBreakTime(
             @PathVariable Long storeId,
             @RequestBody BusinessHoursReqDto.UpdateBreakTimeDto dto
@@ -47,5 +50,4 @@ public class BusinessHoursController {
                 businessHoursCommandService.updateBreakTime(storeId, dto)
         );
     }
-
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/controller/BusinessHoursController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/controller/BusinessHoursController.java
@@ -4,12 +4,16 @@ import com.eatsfine.eatsfine.domain.businesshours.dto.BusinessHoursReqDto;
 import com.eatsfine.eatsfine.domain.businesshours.dto.BusinessHoursResDto;
 import com.eatsfine.eatsfine.domain.businesshours.service.BusinessHoursCommandService;
 import com.eatsfine.eatsfine.domain.businesshours.status.BusinessHoursSuccessStatus;
+import com.eatsfine.eatsfine.global.annotation.CurrentUser;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
 
 @Tag(name = "BusinessHours", description = "영업시간 관련 API")
 @RequestMapping("/api/v1")
@@ -27,11 +31,12 @@ public class BusinessHoursController {
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<BusinessHoursResDto.UpdateBusinessHoursDto> updateBusinessHours(
             @PathVariable Long storeId,
-            @RequestBody BusinessHoursReqDto.UpdateBusinessHoursDto dto
-    ){
+            @RequestBody BusinessHoursReqDto.UpdateBusinessHoursDto dto,
+            @CurrentUser User user
+            ){
         return ApiResponse.of(
                 BusinessHoursSuccessStatus._UPDATE_BUSINESS_HOURS_SUCCESS,
-                businessHoursCommandService.updateBusinessHours(storeId, dto)
+                businessHoursCommandService.updateBusinessHours(storeId, dto, user.getUsername())
         );
     }
 
@@ -43,11 +48,12 @@ public class BusinessHoursController {
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<BusinessHoursResDto.UpdateBreakTimeDto> updateBreakTime(
             @PathVariable Long storeId,
-            @RequestBody BusinessHoursReqDto.UpdateBreakTimeDto dto
+            @RequestBody BusinessHoursReqDto.UpdateBreakTimeDto dto,
+            @CurrentUser User user
     ){
         return ApiResponse.of(
                 BusinessHoursSuccessStatus._UPDATE_BREAKTIME_SUCCESS,
-                businessHoursCommandService.updateBreakTime(storeId, dto)
+                businessHoursCommandService.updateBreakTime(storeId, dto, user.getUsername())
         );
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/service/BusinessHoursCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/service/BusinessHoursCommandService.java
@@ -6,12 +6,14 @@ import com.eatsfine.eatsfine.domain.businesshours.dto.BusinessHoursResDto;
 public interface BusinessHoursCommandService {
     BusinessHoursResDto.UpdateBusinessHoursDto updateBusinessHours(
             Long storeId,
-            BusinessHoursReqDto.UpdateBusinessHoursDto updateBusinessHoursDto
+            BusinessHoursReqDto.UpdateBusinessHoursDto updateBusinessHoursDto,
+            String email
     );
 
     BusinessHoursResDto.UpdateBreakTimeDto updateBreakTime(
             Long storeId,
-            BusinessHoursReqDto.UpdateBreakTimeDto dto
+            BusinessHoursReqDto.UpdateBreakTimeDto dto,
+            String email
     );
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/service/BusinessHoursCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/service/BusinessHoursCommandServiceImpl.java
@@ -10,6 +10,7 @@ import com.eatsfine.eatsfine.domain.store.entity.Store;
 import com.eatsfine.eatsfine.domain.store.exception.StoreException;
 import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
 import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
+import com.eatsfine.eatsfine.domain.store.validator.StoreValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,12 +21,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class BusinessHoursCommandServiceImpl implements BusinessHoursCommandService {
 
     private final StoreRepository storeRepository;
+    private final StoreValidator storeValidator;
 
     @Override
     public BusinessHoursResDto.UpdateBusinessHoursDto updateBusinessHours(
             Long storeId,
-            BusinessHoursReqDto.UpdateBusinessHoursDto dto
+            BusinessHoursReqDto.UpdateBusinessHoursDto dto,
+            String email
     ) {
+
+        storeValidator.validateStoreOwner(storeId, email);
+
         // 영업시간 검증
         BusinessHoursValidator.validateForUpdate(dto.businessHours());
 
@@ -47,10 +53,11 @@ public class BusinessHoursCommandServiceImpl implements BusinessHoursCommandServ
     @Override
     public BusinessHoursResDto.UpdateBreakTimeDto updateBreakTime(
             Long storeId,
-            BusinessHoursReqDto.UpdateBreakTimeDto dto
+            BusinessHoursReqDto.UpdateBreakTimeDto dto,
+            String email
     ) {
-        Store store = storeRepository.findById(storeId)
-                        .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+
+        Store store = storeValidator.validateStoreOwner(storeId, email);
 
         for(BusinessHours bh : store.getBusinessHours()) {
             if(bh.isClosed()) continue;

--- a/src/main/java/com/eatsfine/eatsfine/domain/businessnumber/validator/RealBusinessNumberValidator.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businessnumber/validator/RealBusinessNumberValidator.java
@@ -73,9 +73,16 @@ public class RealBusinessNumberValidator implements BusinessNumberValidator {
             throw new BusinessNumberException(BusinessNumberErrorStatus._INVALID_BUSINESS_NUMBER);
         }
 
-        log.info("[BusinessNumber API] 인증 통과 - 번호: {}", businessNumber);
+        log.info("[BusinessNumber API] 인증 통과 - 번호: {}", maskBusinessNumber(businessNumber));
 
     };
+
+    private String maskBusinessNumber(String businessNumber) {
+        if (businessNumber == null || businessNumber.length() < 6) {
+            return "***";
+        }
+        return businessNumber.substring(0, 3) + "****" + businessNumber.substring(businessNumber.length() - 3);
+    }
 
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/businessnumber/validator/RealBusinessNumberValidator.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businessnumber/validator/RealBusinessNumberValidator.java
@@ -73,6 +73,8 @@ public class RealBusinessNumberValidator implements BusinessNumberValidator {
             throw new BusinessNumberException(BusinessNumberErrorStatus._INVALID_BUSINESS_NUMBER);
         }
 
+        log.info("[BusinessNumber API] 인증 통과 - 번호: {}", businessNumber);
+
     };
 
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/menu/controller/MenuController.java
@@ -5,6 +5,7 @@ import com.eatsfine.eatsfine.domain.menu.dto.MenuResDto;
 import com.eatsfine.eatsfine.domain.menu.service.MenuCommandService;
 import com.eatsfine.eatsfine.domain.menu.service.MenuQueryService;
 import com.eatsfine.eatsfine.domain.menu.status.MenuSuccessStatus;
+import com.eatsfine.eatsfine.global.annotation.CurrentUser;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -29,9 +31,10 @@ public class MenuController {
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<MenuResDto.ImageUploadDto> uploadImage(
             @PathVariable Long storeId,
-            @RequestPart("image") MultipartFile file
-    ){
-        return ApiResponse.of(MenuSuccessStatus._MENU_IMAGE_UPLOAD_SUCCESS, menuCommandService.uploadImage(storeId, file));
+            @RequestPart("image") MultipartFile file,
+            @CurrentUser User user
+            ){
+        return ApiResponse.of(MenuSuccessStatus._MENU_IMAGE_UPLOAD_SUCCESS, menuCommandService.uploadImage(storeId, file, user.getUsername()));
     }
 
     @Operation(summary = "메뉴 등록 API", description = "가게의 메뉴들을 등록합니다.")
@@ -39,9 +42,10 @@ public class MenuController {
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<MenuResDto.MenuCreateDto> createMenus(
             @PathVariable Long storeId,
-            @RequestBody @Valid MenuReqDto.MenuCreateDto dto
+            @RequestBody @Valid MenuReqDto.MenuCreateDto dto,
+            @CurrentUser User user
     ) {
-        return ApiResponse.of(MenuSuccessStatus._MENU_CREATE_SUCCESS, menuCommandService.createMenus(storeId, dto));
+        return ApiResponse.of(MenuSuccessStatus._MENU_CREATE_SUCCESS, menuCommandService.createMenus(storeId, dto, user.getUsername()));
     }
 
     @Operation(summary = "메뉴 삭제 API", description = "가게의 메뉴들을 삭제합니다.")
@@ -49,9 +53,10 @@ public class MenuController {
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<MenuResDto.MenuDeleteDto> deleteMenus(
             @PathVariable Long storeId,
-            @RequestBody @Valid MenuReqDto.MenuDeleteDto dto
+            @RequestBody @Valid MenuReqDto.MenuDeleteDto dto,
+            @CurrentUser User user
     ) {
-        return ApiResponse.of(MenuSuccessStatus._MENU_DELETE_SUCCESS, menuCommandService.deleteMenus(storeId, dto));
+        return ApiResponse.of(MenuSuccessStatus._MENU_DELETE_SUCCESS, menuCommandService.deleteMenus(storeId, dto, user.getUsername()));
     }
 
     @Operation(summary = "메뉴 수정 API", description = "가게의 메뉴를 수정합니다.")
@@ -60,9 +65,10 @@ public class MenuController {
     public ApiResponse<MenuResDto.MenuUpdateDto> updateMenu(
             @PathVariable Long storeId,
             @PathVariable Long menuId,
-            @RequestBody @Valid MenuReqDto.MenuUpdateDto dto
+            @RequestBody @Valid MenuReqDto.MenuUpdateDto dto,
+            @CurrentUser User user
     ) {
-        return ApiResponse.of(MenuSuccessStatus._MENU_UPDATE_SUCCESS, menuCommandService.updateMenu(storeId, menuId, dto));
+        return ApiResponse.of(MenuSuccessStatus._MENU_UPDATE_SUCCESS, menuCommandService.updateMenu(storeId, menuId, dto, user.getUsername()));
     }
 
     @Operation(summary = "품절 여부 변경 API", description = "메뉴의 품절 여부를 변경합니다.")
@@ -71,9 +77,10 @@ public class MenuController {
     public ApiResponse<MenuResDto.SoldOutUpdateDto> updateSoldOutStatus(
             @PathVariable Long storeId,
             @PathVariable Long menuId,
-            @RequestBody @Valid MenuReqDto.SoldOutUpdateDto dto
+            @RequestBody @Valid MenuReqDto.SoldOutUpdateDto dto,
+            @CurrentUser User user
     ){
-        return ApiResponse.of(MenuSuccessStatus._SOLD_OUT_UPDATE_SUCCESS, menuCommandService.updateSoldOutStatus(storeId, menuId, dto.isSoldOut()));
+        return ApiResponse.of(MenuSuccessStatus._SOLD_OUT_UPDATE_SUCCESS, menuCommandService.updateSoldOutStatus(storeId, menuId, dto.isSoldOut(), user.getUsername()));
     }
 
     @Operation(summary = "등록된 메뉴 이미지 삭제 API", description = "이미 등록된 메뉴의 이미지를 삭제합니다.")
@@ -81,9 +88,10 @@ public class MenuController {
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<MenuResDto.ImageDeleteDto> deleteMenuImage(
             @PathVariable Long storeId,
-            @PathVariable Long menuId
+            @PathVariable Long menuId,
+            @CurrentUser User user
     ) {
-        return ApiResponse.of(MenuSuccessStatus._MENU_IMAGE_DELETE_SUCCESS, menuCommandService.deleteMenuImage(storeId, menuId));
+        return ApiResponse.of(MenuSuccessStatus._MENU_IMAGE_DELETE_SUCCESS, menuCommandService.deleteMenuImage(storeId, menuId, user.getUsername()));
     }
 
     @Operation(summary = "메뉴 조회 API", description = "가게의 메뉴들을 조회합니다.")

--- a/src/main/java/com/eatsfine/eatsfine/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/menu/controller/MenuController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -25,6 +26,7 @@ public class MenuController {
 
     @Operation(summary = "메뉴 이미지 선 업로드 API", description = "메뉴 등록 전에 이미지를 먼저 업로드하고 KEY를 반환합니다.")
     @PostMapping(value = "/stores/{storeId}/menus/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<MenuResDto.ImageUploadDto> uploadImage(
             @PathVariable Long storeId,
             @RequestPart("image") MultipartFile file
@@ -34,6 +36,7 @@ public class MenuController {
 
     @Operation(summary = "메뉴 등록 API", description = "가게의 메뉴들을 등록합니다.")
     @PostMapping("/stores/{storeId}/menus")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<MenuResDto.MenuCreateDto> createMenus(
             @PathVariable Long storeId,
             @RequestBody @Valid MenuReqDto.MenuCreateDto dto
@@ -43,6 +46,7 @@ public class MenuController {
 
     @Operation(summary = "메뉴 삭제 API", description = "가게의 메뉴들을 삭제합니다.")
     @DeleteMapping("/stores/{storeId}/menus")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<MenuResDto.MenuDeleteDto> deleteMenus(
             @PathVariable Long storeId,
             @RequestBody @Valid MenuReqDto.MenuDeleteDto dto
@@ -52,6 +56,7 @@ public class MenuController {
 
     @Operation(summary = "메뉴 수정 API", description = "가게의 메뉴를 수정합니다.")
     @PatchMapping("/stores/{storeId}/menus/{menuId}")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<MenuResDto.MenuUpdateDto> updateMenu(
             @PathVariable Long storeId,
             @PathVariable Long menuId,
@@ -62,6 +67,7 @@ public class MenuController {
 
     @Operation(summary = "품절 여부 변경 API", description = "메뉴의 품절 여부를 변경합니다.")
     @PatchMapping("/stores/{storeId}/menus/{menuId}/sold-out")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<MenuResDto.SoldOutUpdateDto> updateSoldOutStatus(
             @PathVariable Long storeId,
             @PathVariable Long menuId,
@@ -72,6 +78,7 @@ public class MenuController {
 
     @Operation(summary = "등록된 메뉴 이미지 삭제 API", description = "이미 등록된 메뉴의 이미지를 삭제합니다.")
     @DeleteMapping("/stores/{storeId}/menus/{menuId}/image")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<MenuResDto.ImageDeleteDto> deleteMenuImage(
             @PathVariable Long storeId,
             @PathVariable Long menuId

--- a/src/main/java/com/eatsfine/eatsfine/domain/menu/service/MenuCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/menu/service/MenuCommandService.java
@@ -5,11 +5,11 @@ import com.eatsfine.eatsfine.domain.menu.dto.MenuResDto;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface MenuCommandService {
-    MenuResDto.ImageUploadDto uploadImage(Long storeId, MultipartFile file);
-    MenuResDto.ImageDeleteDto deleteMenuImage(Long storeId, Long menuId);
-    MenuResDto.MenuCreateDto createMenus(Long storeId, MenuReqDto.MenuCreateDto menuCreateDto);
-    MenuResDto.MenuDeleteDto deleteMenus(Long storeId, MenuReqDto.MenuDeleteDto menuDeleteDto);
-    MenuResDto.MenuUpdateDto updateMenu(Long storeId, Long menuId, MenuReqDto.MenuUpdateDto menuUpdateDto);
-    MenuResDto.SoldOutUpdateDto updateSoldOutStatus(Long storeId, Long menuId, boolean isSoldOut);
+    MenuResDto.ImageUploadDto uploadImage(Long storeId, MultipartFile file, String email);
+    MenuResDto.ImageDeleteDto deleteMenuImage(Long storeId, Long menuId, String email);
+    MenuResDto.MenuCreateDto createMenus(Long storeId, MenuReqDto.MenuCreateDto menuCreateDto, String email);
+    MenuResDto.MenuDeleteDto deleteMenus(Long storeId, MenuReqDto.MenuDeleteDto menuDeleteDto, String email);
+    MenuResDto.MenuUpdateDto updateMenu(Long storeId, Long menuId, MenuReqDto.MenuUpdateDto menuUpdateDto, String email);
+    MenuResDto.SoldOutUpdateDto updateSoldOutStatus(Long storeId, Long menuId, boolean isSoldOut, String email);
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/menu/service/MenuCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/menu/service/MenuCommandServiceImpl.java
@@ -272,7 +272,7 @@ public class MenuCommandServiceImpl implements MenuCommandService {
     private void verifyMenuBelongsToStore(Menu menu, Long storeId) {
         if (!menu.getStore().getId().equals(storeId)) {
             // 다른 가게의 메뉴를 조작하려는 시도 방지
-            throw new StoreException(StoreErrorStatus._STORE_NOT_OWNER);
+            throw new StoreException(StoreErrorStatus._NOT_STORE_OWNER);
         }
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/controller/StoreController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/controller/StoreController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -30,6 +31,7 @@ public class StoreController {
             description = "사장 회원이 새로운 식당을 등록합니다"
     )
     @PostMapping("/stores")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreResDto.StoreCreateDto> createStore(
             @Valid @RequestBody StoreReqDto.StoreCreateDto dto
     ) {
@@ -65,6 +67,7 @@ public class StoreController {
                     "영업시간, 브레이크타임, 이미지는 별도 엔티티/컬렉션이므로 개별 API로 분리"
     )
     @PatchMapping("/stores/{storeId}")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreResDto.StoreUpdateDto> updateStoreBasicInfo(
             @PathVariable Long storeId,
             @Valid @RequestBody StoreReqDto.StoreUpdateDto dto
@@ -81,6 +84,7 @@ public class StoreController {
             value = "/stores/{storeId}/main-image",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE
     )
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreResDto.UploadMainImageDto> uploadMainImage(
             @RequestPart("mainImage")MultipartFile mainImage,
             @PathVariable Long storeId

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/controller/StoreController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/controller/StoreController.java
@@ -6,6 +6,7 @@ import com.eatsfine.eatsfine.domain.store.dto.StoreResDto;
 import com.eatsfine.eatsfine.domain.store.service.StoreCommandService;
 import com.eatsfine.eatsfine.domain.store.service.StoreQueryService;
 import com.eatsfine.eatsfine.domain.store.status.StoreSuccessStatus;
+import com.eatsfine.eatsfine.global.annotation.CurrentUser;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -33,9 +35,10 @@ public class StoreController {
     @PostMapping("/stores")
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreResDto.StoreCreateDto> createStore(
-            @Valid @RequestBody StoreReqDto.StoreCreateDto dto
+            @Valid @RequestBody StoreReqDto.StoreCreateDto dto,
+            @CurrentUser User user
     ) {
-        return ApiResponse.of(StoreSuccessStatus._STORE_CREATED, storeCommandService.createStore(dto));
+        return ApiResponse.of(StoreSuccessStatus._STORE_CREATED, storeCommandService.createStore(dto, user.getUsername()));
     }
 
     @Operation(
@@ -70,9 +73,10 @@ public class StoreController {
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreResDto.StoreUpdateDto> updateStoreBasicInfo(
             @PathVariable Long storeId,
-            @Valid @RequestBody StoreReqDto.StoreUpdateDto dto
+            @Valid @RequestBody StoreReqDto.StoreUpdateDto dto,
+            @CurrentUser User user
             ) {
-        return ApiResponse.of(StoreSuccessStatus._STORE_UPDATE_SUCCESS, storeCommandService.updateBasicInfo(storeId, dto));
+        return ApiResponse.of(StoreSuccessStatus._STORE_UPDATE_SUCCESS, storeCommandService.updateBasicInfo(storeId, dto, user.getUsername()));
     }
 
 
@@ -87,9 +91,10 @@ public class StoreController {
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreResDto.UploadMainImageDto> uploadMainImage(
             @RequestPart("mainImage")MultipartFile mainImage,
-            @PathVariable Long storeId
+            @PathVariable Long storeId,
+            @CurrentUser User user
             ){
-        return ApiResponse.of(StoreSuccessStatus._STORE_MAIN_IMAGE_UPLOAD_SUCCESS, storeCommandService.uploadMainImage(storeId, mainImage));
+        return ApiResponse.of(StoreSuccessStatus._STORE_MAIN_IMAGE_UPLOAD_SUCCESS, storeCommandService.uploadMainImage(storeId, mainImage, user.getUsername()));
     }
 
     @Operation(

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/dto/StoreResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/dto/StoreResDto.java
@@ -34,7 +34,9 @@ public class StoreResDto {
     public record PaginationDto(
             int currentPage,
             int totalPages,
-            long totalCount
+            long totalCount,
+            boolean isFirst,
+            boolean isLast
     ){}
 
     @Builder

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/entity/Store.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/entity/Store.java
@@ -40,7 +40,7 @@ public class Store extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_id") // 임시 nullable 허용 (User 도메인 머지 후 owner 처리 예정)
+    @JoinColumn(name = "owner_id", nullable = false)
     private User owner;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreCommandService.java
@@ -5,7 +5,7 @@ import com.eatsfine.eatsfine.domain.store.dto.StoreResDto;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface StoreCommandService {
-    StoreResDto.StoreCreateDto createStore(StoreReqDto.StoreCreateDto storeCreateDto);
-    StoreResDto.StoreUpdateDto updateBasicInfo(Long storeId, StoreReqDto.StoreUpdateDto storeUpdateDto);
-    StoreResDto.UploadMainImageDto uploadMainImage(Long storeId, MultipartFile file);
+    StoreResDto.StoreCreateDto createStore(StoreReqDto.StoreCreateDto storeCreateDto, String email);
+    StoreResDto.StoreUpdateDto updateBasicInfo(Long storeId, StoreReqDto.StoreUpdateDto storeUpdateDto, String email);
+    StoreResDto.UploadMainImageDto uploadMainImage(Long storeId, MultipartFile file, String email);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreCommandServiceImpl.java
@@ -15,7 +15,11 @@ import com.eatsfine.eatsfine.domain.store.dto.StoreResDto;
 import com.eatsfine.eatsfine.domain.store.entity.Store;
 import com.eatsfine.eatsfine.domain.store.exception.StoreException;
 import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
-import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
+import com.eatsfine.eatsfine.domain.store.validator.StoreValidator;
+import com.eatsfine.eatsfine.domain.user.entity.User;
+import com.eatsfine.eatsfine.domain.user.exception.UserException;
+import com.eatsfine.eatsfine.domain.user.repository.UserRepository;
+import com.eatsfine.eatsfine.domain.user.status.UserErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,13 +40,21 @@ public class StoreCommandServiceImpl implements StoreCommandService {
     private final RegionRepository regionRepository;
     private final S3Service s3Service;
     private final BusinessNumberValidator businessNumberValidator;
+    private final StoreValidator storeValidator;
+    private final UserRepository userRepository;
 
     // 가게 등록
     @Override
-    public StoreResDto.StoreCreateDto createStore(StoreReqDto.StoreCreateDto dto) {
+    public StoreResDto.StoreCreateDto createStore(StoreReqDto.StoreCreateDto dto, String email) {
 
-        // TODO: 추후 Security Context 연동 시, 로그인된 사용자의 이름을 가져오도록 수정 예정
-        businessNumberValidator.validate(dto.businessNumberDto().businessNumber(), dto.businessNumberDto().startDate(), "홍길동");
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(UserErrorStatus.MEMBER_NOT_FOUND));
+
+        businessNumberValidator.validate(
+                dto.businessNumberDto().businessNumber(),
+                dto.businessNumberDto().startDate(),
+                user.getName());
+
         log.info("사업자 번호 검증 성공: {}", dto.businessNumberDto().businessNumber());
 
 
@@ -55,7 +67,7 @@ public class StoreCommandServiceImpl implements StoreCommandService {
         BusinessHoursValidator.validateForCreate(dto.businessHours());
 
         Store store = Store.builder()
-                .owner(null) // User 도메인 머지 후 owner 처리 예정
+                .owner(user)
                 .storeName(dto.storeName())
                 .businessNumber(dto.businessNumberDto().businessNumber())
                 .description(dto.description())
@@ -82,9 +94,8 @@ public class StoreCommandServiceImpl implements StoreCommandService {
 
     // 가게 기본 정보 수정 (필드)
     @Override
-    public StoreResDto.StoreUpdateDto updateBasicInfo(Long storeId, StoreReqDto.StoreUpdateDto dto) {
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+    public StoreResDto.StoreUpdateDto updateBasicInfo(Long storeId, StoreReqDto.StoreUpdateDto dto, String email) {
+        Store store = storeValidator.validateStoreOwner(storeId, email);
 
         store.updateBasicInfo(dto);
         List<String> updatedFields = extractUpdatedFields(dto);
@@ -107,10 +118,8 @@ public class StoreCommandServiceImpl implements StoreCommandService {
     }
     // 가게 메인 이미지 등록
     @Override
-    public StoreResDto.UploadMainImageDto uploadMainImage(Long storeId, MultipartFile file) {
-        Store store = storeRepository.findById(storeId).orElseThrow(
-                () -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND)
-        );
+    public StoreResDto.UploadMainImageDto uploadMainImage(Long storeId, MultipartFile file, String email) {
+        Store store = storeValidator.validateStoreOwner(storeId, email);
 
         if(file.isEmpty()) {
             throw new ImageException(ImageErrorStatus.EMPTY_FILE);

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryServiceImpl.java
@@ -61,6 +61,8 @@ public class StoreQueryServiceImpl implements StoreQueryService {
                                 .currentPage(page)
                                 .totalPages(resultPage.getTotalPages())
                                 .totalCount(resultPage.getTotalElements())
+                                .isFirst(resultPage.isFirst())
+                                .isLast(resultPage.isLast())
                                 .build()
                 )
                 .build();

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreErrorStatus.java
@@ -15,7 +15,7 @@ public enum StoreErrorStatus implements BaseErrorCode {
     _STORE_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE_DETAIL404", "가게 상세 정보를 찾을 수 없습니다."),
     _STORE_NOT_OPEN_ON_DAY(HttpStatus.NOT_FOUND,"STORE4041" , "해당 영업시간 정보를 찾을 수 없습니다."),
 
-    _STORE_NOT_OWNER(HttpStatus.FORBIDDEN, "STORE403", "해당 가게의 주인이 아닙니다."),
+    _NOT_STORE_OWNER(HttpStatus.FORBIDDEN, "STORE403", "해당 가게의 주인이 아닙니다."),
     ;
 
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/validator/StoreValidator.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/validator/StoreValidator.java
@@ -1,0 +1,24 @@
+package com.eatsfine.eatsfine.domain.store.validator;
+
+import com.eatsfine.eatsfine.domain.store.entity.Store;
+import com.eatsfine.eatsfine.domain.store.exception.StoreException;
+import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
+import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StoreValidator {
+    private final StoreRepository storeRepository;
+
+    public void validateStoreOwner(Long storeId, String email) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+
+        if(!store.getOwner().getEmail().equals(email)) {
+            throw new StoreException(StoreErrorStatus._NOT_STORE_OWNER);
+        }
+
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/validator/StoreValidator.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/validator/StoreValidator.java
@@ -16,7 +16,7 @@ public class StoreValidator {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
 
-        if(!store.getOwner().getEmail().equals(email)) {
+        if(store.getOwner() == null || !store.getOwner().getEmail().equals(email)) {
             throw new StoreException(StoreErrorStatus._NOT_STORE_OWNER);
         }
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/validator/StoreValidator.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/validator/StoreValidator.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 public class StoreValidator {
     private final StoreRepository storeRepository;
 
-    public void validateStoreOwner(Long storeId, String email) {
+    public Store validateStoreOwner(Long storeId, String email) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
 
@@ -20,5 +20,6 @@ public class StoreValidator {
             throw new StoreException(StoreErrorStatus._NOT_STORE_OWNER);
         }
 
+        return store;
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
@@ -6,6 +6,7 @@ import com.eatsfine.eatsfine.domain.storetable.exception.status.StoreTableSucces
 import com.eatsfine.eatsfine.domain.storetable.service.StoreTableCommandService;
 import com.eatsfine.eatsfine.domain.storetable.service.StoreTableQueryService;
 import com.eatsfine.eatsfine.domain.tableimage.status.TableImageSuccessStatus;
+import com.eatsfine.eatsfine.global.annotation.CurrentUser;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -13,12 +14,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 
-import java.time.LocalDate;
 
 @Tag(name = "StoreTable", description = "가게 테이블 관리 API")
 @RestController
@@ -32,18 +33,20 @@ public class StoreTableController implements StoreTableControllerDocs {
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreTableResDto.TableCreateDto> createTable(
             @PathVariable Long storeId,
-            @RequestBody StoreTableReqDto.TableCreateDto dto
-    ) {
-        return ApiResponse.of(StoreTableSuccessStatus._TABLE_CREATED, storeTableCommandService.createTable(storeId, dto));
+            @RequestBody StoreTableReqDto.TableCreateDto dto,
+            @CurrentUser User user
+            ) {
+        return ApiResponse.of(StoreTableSuccessStatus._TABLE_CREATED, storeTableCommandService.createTable(storeId, dto, user.getUsername()));
     }
 
     @PostMapping(value = "/stores/{storeId}/tables/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreTableResDto.ImageUploadDto> uploadTableImageTemp(
             @PathVariable Long storeId,
-            @RequestPart("image") MultipartFile file
+            @RequestPart("image") MultipartFile file,
+            @CurrentUser User user
     ) {
-        return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_UPLOAD_SUCCESS, storeTableCommandService.uploadTableImageTemp(storeId, file));
+        return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_UPLOAD_SUCCESS, storeTableCommandService.uploadTableImageTemp(storeId, file, user.getUsername()));
     }
 
     @GetMapping("/stores/{storeId}/tables/{tableId}/slots")
@@ -71,18 +74,20 @@ public class StoreTableController implements StoreTableControllerDocs {
     public ApiResponse<StoreTableResDto.TableUpdateResultDto> updateTable(
             @PathVariable Long storeId,
             @PathVariable Long tableId,
-            @RequestBody @Valid StoreTableReqDto.TableUpdateDto dto
+            @RequestBody @Valid StoreTableReqDto.TableUpdateDto dto,
+            @CurrentUser User user
     ) {
-        return ApiResponse.of(StoreTableSuccessStatus._TABLE_UPDATED, storeTableCommandService.updateTable(storeId, tableId, dto));
+        return ApiResponse.of(StoreTableSuccessStatus._TABLE_UPDATED, storeTableCommandService.updateTable(storeId, tableId, dto, user.getUsername()));
     }
 
     @DeleteMapping("/stores/{storeId}/tables/{tableId}")
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreTableResDto.TableDeleteDto> deleteTable(
             @PathVariable Long storeId,
-            @PathVariable Long tableId
+            @PathVariable Long tableId,
+            @CurrentUser User user
     ) {
-        return ApiResponse.of(StoreTableSuccessStatus._TABLE_DELETED, storeTableCommandService.deleteTable(storeId, tableId));
+        return ApiResponse.of(StoreTableSuccessStatus._TABLE_DELETED, storeTableCommandService.deleteTable(storeId, tableId, user.getUsername()));
     }
 
     @PostMapping(
@@ -93,17 +98,19 @@ public class StoreTableController implements StoreTableControllerDocs {
     public ApiResponse<StoreTableResDto.UploadTableImageDto> uploadTableImage(
             @PathVariable Long storeId,
             @PathVariable Long tableId,
-            @RequestPart("tableImage") MultipartFile tableImage
+            @RequestPart("tableImage") MultipartFile tableImage,
+            @CurrentUser User user
     ) {
-        return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_UPLOAD_SUCCESS, storeTableCommandService.uploadTableImage(storeId, tableId, tableImage));
+        return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_UPLOAD_SUCCESS, storeTableCommandService.uploadTableImage(storeId, tableId, tableImage, user.getUsername()));
     }
 
     @DeleteMapping("/stores/{storeId}/tables/{tableId}/table-image")
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreTableResDto.DeleteTableImageDto> deleteTableImage(
             @PathVariable Long storeId,
-            @PathVariable Long tableId
+            @PathVariable Long tableId,
+            @CurrentUser User user
     ) {
-        return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_DELETE_SUCCESS, storeTableCommandService.deleteTableImage(storeId, tableId));
+        return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_DELETE_SUCCESS, storeTableCommandService.deleteTableImage(storeId, tableId, user.getUsername()));
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -28,6 +29,7 @@ public class StoreTableController implements StoreTableControllerDocs {
     private final StoreTableQueryService storeTableQueryService;
 
     @PostMapping("/stores/{storeId}/tables")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreTableResDto.TableCreateDto> createTable(
             @PathVariable Long storeId,
             @RequestBody StoreTableReqDto.TableCreateDto dto
@@ -36,6 +38,7 @@ public class StoreTableController implements StoreTableControllerDocs {
     }
 
     @PostMapping(value = "/stores/{storeId}/tables/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreTableResDto.ImageUploadDto> uploadTableImageTemp(
             @PathVariable Long storeId,
             @RequestPart("image") MultipartFile file
@@ -64,6 +67,7 @@ public class StoreTableController implements StoreTableControllerDocs {
     }
 
     @PatchMapping("/stores/{storeId}/tables/{tableId}")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreTableResDto.TableUpdateResultDto> updateTable(
             @PathVariable Long storeId,
             @PathVariable Long tableId,
@@ -73,6 +77,7 @@ public class StoreTableController implements StoreTableControllerDocs {
     }
 
     @DeleteMapping("/stores/{storeId}/tables/{tableId}")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreTableResDto.TableDeleteDto> deleteTable(
             @PathVariable Long storeId,
             @PathVariable Long tableId
@@ -84,6 +89,7 @@ public class StoreTableController implements StoreTableControllerDocs {
             value = "/stores/{storeId}/tables/{tableId}/table-image",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE
     )
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreTableResDto.UploadTableImageDto> uploadTableImage(
             @PathVariable Long storeId,
             @PathVariable Long tableId,
@@ -93,6 +99,7 @@ public class StoreTableController implements StoreTableControllerDocs {
     }
 
     @DeleteMapping("/stores/{storeId}/tables/{tableId}/table-image")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreTableResDto.DeleteTableImageDto> deleteTableImage(
             @PathVariable Long storeId,
             @PathVariable Long tableId

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
@@ -33,7 +33,7 @@ public class StoreTableController implements StoreTableControllerDocs {
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreTableResDto.TableCreateDto> createTable(
             @PathVariable Long storeId,
-            @RequestBody StoreTableReqDto.TableCreateDto dto,
+            @RequestBody @Valid StoreTableReqDto.TableCreateDto dto,
             @CurrentUser User user
             ) {
         return ApiResponse.of(StoreTableSuccessStatus._TABLE_CREATED, storeTableCommandService.createTable(storeId, dto, user.getUsername()));

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
@@ -40,7 +41,8 @@ public interface StoreTableControllerDocs {
     ApiResponse<StoreTableResDto.TableCreateDto> createTable(
             @Parameter(description = "가게 ID", required = true, example = "1")
             Long storeId,
-            @RequestBody @Valid StoreTableReqDto.TableCreateDto dto
+            @RequestBody @Valid StoreTableReqDto.TableCreateDto dto,
+            @Parameter(hidden = true) User user
     );
 
     @Operation(
@@ -68,7 +70,8 @@ public interface StoreTableControllerDocs {
                     required = true,
                     content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
             )
-            MultipartFile file
+            MultipartFile file,
+            @Parameter(hidden = true) User user
     );
 
     @Operation(
@@ -194,7 +197,9 @@ public interface StoreTableControllerDocs {
             @Parameter(description = "테이블 ID", required = true, example = "1")
             Long tableId,
 
-            @RequestBody @Valid StoreTableReqDto.TableUpdateDto dto
+            @RequestBody @Valid StoreTableReqDto.TableUpdateDto dto,
+
+            @Parameter(hidden = true) User user
     );
 
     @Operation(
@@ -218,7 +223,8 @@ public interface StoreTableControllerDocs {
             @Parameter(description = "가게 ID", required = true, example = "1")
             Long storeId,
             @Parameter(description = "테이블 ID", required = true, example = "1")
-            Long tableId
+            Long tableId,
+            @Parameter(hidden = true) User user
     );
 
     @Operation(
@@ -249,7 +255,9 @@ public interface StoreTableControllerDocs {
                     required = true,
                     content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
             )
-            MultipartFile tableImage
+            MultipartFile tableImage,
+
+            @Parameter(hidden = true) User user
     );
 
     @Operation(
@@ -272,6 +280,8 @@ public interface StoreTableControllerDocs {
             Long storeId,
 
             @Parameter(description = "테이블 ID", required = true, example = "1")
-            Long tableId
+            Long tableId,
+
+            @Parameter(hidden = true) User user
     );
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandService.java
@@ -5,15 +5,15 @@ import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface StoreTableCommandService {
-    StoreTableResDto.TableCreateDto createTable(Long storeId, StoreTableReqDto.TableCreateDto dto);
+    StoreTableResDto.TableCreateDto createTable(Long storeId, StoreTableReqDto.TableCreateDto dto, String email);
 
-    StoreTableResDto.ImageUploadDto uploadTableImageTemp(Long storeId, MultipartFile file);
+    StoreTableResDto.ImageUploadDto uploadTableImageTemp(Long storeId, MultipartFile file, String email);
 
-    StoreTableResDto.TableUpdateResultDto updateTable(Long storeId, Long tableId, StoreTableReqDto.TableUpdateDto dto);
+    StoreTableResDto.TableUpdateResultDto updateTable(Long storeId, Long tableId, StoreTableReqDto.TableUpdateDto dto, String email);
 
-    StoreTableResDto.TableDeleteDto deleteTable(Long storeId, Long tableId);
+    StoreTableResDto.TableDeleteDto deleteTable(Long storeId, Long tableId, String email);
 
-    StoreTableResDto.UploadTableImageDto uploadTableImage(Long storeId, Long tableId, MultipartFile tableImage);
+    StoreTableResDto.UploadTableImageDto uploadTableImage(Long storeId, Long tableId, MultipartFile tableImage, String email);
 
-    StoreTableResDto.DeleteTableImageDto deleteTableImage(Long storeId, Long tableId);
+    StoreTableResDto.DeleteTableImageDto deleteTableImage(Long storeId, Long tableId, String email);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableCommandServiceImpl.java
@@ -6,6 +6,7 @@ import com.eatsfine.eatsfine.domain.image.status.ImageErrorStatus;
 import com.eatsfine.eatsfine.domain.store.exception.StoreException;
 import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
 import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
+import com.eatsfine.eatsfine.domain.store.validator.StoreValidator;
 import com.eatsfine.eatsfine.domain.storetable.converter.StoreTableConverter;
 import com.eatsfine.eatsfine.domain.storetable.dto.req.StoreTableReqDto;
 import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
@@ -45,12 +46,12 @@ public class StoreTableCommandServiceImpl implements StoreTableCommandService {
     private final StoreTableRepository storeTableRepository;
     private final BookingRepository bookingRepository;
     private final S3Service s3Service;
+    private final StoreValidator storeValidator;
 
     // 테이블 생성
     @Override
-    public StoreTableResDto.TableCreateDto createTable(Long storeId, StoreTableReqDto.TableCreateDto dto) {
-        storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+    public StoreTableResDto.TableCreateDto createTable(Long storeId, StoreTableReqDto.TableCreateDto dto, String email) {
+        storeValidator.validateStoreOwner(storeId, email);
 
         TableLayout layout = tableLayoutRepository.findByStoreIdAndIsActiveTrue(storeId)
                 .orElseThrow(() -> new TableLayoutException(TableLayoutErrorStatus._LAYOUT_NOT_FOUND));
@@ -119,9 +120,9 @@ public class StoreTableCommandServiceImpl implements StoreTableCommandService {
     }
 
     @Override
-    public StoreTableResDto.ImageUploadDto uploadTableImageTemp(Long storeId, MultipartFile file) {
-        storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+    public StoreTableResDto.ImageUploadDto uploadTableImageTemp(Long storeId, MultipartFile file, String email) {
+
+        storeValidator.validateStoreOwner(storeId, email);
 
         if (file.isEmpty()) {
             throw new ImageException(ImageErrorStatus.EMPTY_FILE);
@@ -136,14 +137,19 @@ public class StoreTableCommandServiceImpl implements StoreTableCommandService {
 
     // 테이블 정보 수정
     @Override
-    public StoreTableResDto.TableUpdateResultDto updateTable(Long storeId, Long tableId, StoreTableReqDto.TableUpdateDto dto) {
+    public StoreTableResDto.TableUpdateResultDto updateTable(
+            Long storeId,
+            Long tableId,
+            StoreTableReqDto.TableUpdateDto dto,
+            String email
+    )
+    {
+        storeValidator.validateStoreOwner(storeId, email);
+
         // 최소 하나의 변경사항이 있는지 확인
         if (!dto.hasAnyUpdate()) {
             throw new StoreTableException(StoreTableErrorStatus._NO_UPDATE_FIELD);
         }
-
-        storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
 
         StoreTable table = storeTableRepository.findById(tableId)
                 .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._TABLE_NOT_FOUND));
@@ -192,9 +198,9 @@ public class StoreTableCommandServiceImpl implements StoreTableCommandService {
 
     // 테이블 삭제
     @Override
-    public StoreTableResDto.TableDeleteDto deleteTable(Long storeId, Long tableId) {
-        storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+    public StoreTableResDto.TableDeleteDto deleteTable(Long storeId, Long tableId, String email) {
+
+        storeValidator.validateStoreOwner(storeId, email);
 
         StoreTable table = storeTableRepository.findById(tableId)
                 .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._TABLE_NOT_FOUND));
@@ -231,9 +237,14 @@ public class StoreTableCommandServiceImpl implements StoreTableCommandService {
 
     // 테이블 이미지 업로드
     @Override
-    public StoreTableResDto.UploadTableImageDto uploadTableImage(Long storeId, Long tableId, MultipartFile tableImage) {
-        storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+    public StoreTableResDto.UploadTableImageDto uploadTableImage(
+            Long storeId,
+            Long tableId,
+            MultipartFile tableImage,
+            String email
+            ) {
+
+        storeValidator.validateStoreOwner(storeId, email);
 
         StoreTable table = storeTableRepository.findById(tableId)
                 .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._TABLE_NOT_FOUND));
@@ -260,9 +271,9 @@ public class StoreTableCommandServiceImpl implements StoreTableCommandService {
     }
 
     @Override
-    public StoreTableResDto.DeleteTableImageDto deleteTableImage(Long storeId, Long tableId) {
-        storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+    public StoreTableResDto.DeleteTableImageDto deleteTableImage(Long storeId, Long tableId, String email) {
+
+        storeValidator.validateStoreOwner(storeId, email);
 
         StoreTable table = storeTableRepository.findById(tableId)
                 .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._TABLE_NOT_FOUND));

--- a/src/main/java/com/eatsfine/eatsfine/domain/table_layout/controller/TableLayoutController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/table_layout/controller/TableLayoutController.java
@@ -8,6 +8,7 @@ import com.eatsfine.eatsfine.domain.table_layout.service.TableLayoutQueryService
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "TableLayout", description = "테이블 배치도 조회 및 관리 API")
@@ -19,6 +20,7 @@ public class TableLayoutController implements TableLayoutControllerDocs{
     private final TableLayoutQueryService tableLayoutQueryService;
 
     @PostMapping("stores/{storeId}/layouts")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<TableLayoutResDto.LayoutDetailDto> createLayout(
             @PathVariable Long storeId,
             @RequestBody TableLayoutReqDto.LayoutCreateDto dto

--- a/src/main/java/com/eatsfine/eatsfine/domain/table_layout/controller/TableLayoutController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/table_layout/controller/TableLayoutController.java
@@ -5,10 +5,12 @@ import com.eatsfine.eatsfine.domain.table_layout.dto.res.TableLayoutResDto;
 import com.eatsfine.eatsfine.domain.table_layout.exception.status.TableLayoutSuccessStatus;
 import com.eatsfine.eatsfine.domain.table_layout.service.TableLayoutCommandService;
 import com.eatsfine.eatsfine.domain.table_layout.service.TableLayoutQueryService;
+import com.eatsfine.eatsfine.global.annotation.CurrentUser;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "TableLayout", description = "테이블 배치도 조회 및 관리 API")
@@ -23,14 +25,19 @@ public class TableLayoutController implements TableLayoutControllerDocs{
     @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<TableLayoutResDto.LayoutDetailDto> createLayout(
             @PathVariable Long storeId,
-            @RequestBody TableLayoutReqDto.LayoutCreateDto dto
+            @RequestBody TableLayoutReqDto.LayoutCreateDto dto,
+            @CurrentUser User user
     ) {
-        return ApiResponse.of(TableLayoutSuccessStatus._LAYOUT_CREATED, tableLayoutCommandService.createLayout(storeId, dto));
+        return ApiResponse.of(TableLayoutSuccessStatus._LAYOUT_CREATED, tableLayoutCommandService.createLayout(storeId, dto, user.getUsername()));
     }
 
     @GetMapping("stores/{storeId}/layouts")
-    public ApiResponse<TableLayoutResDto.LayoutDetailDto> getActiveLayout(@PathVariable Long storeId) {
-        TableLayoutResDto.LayoutDetailDto result = tableLayoutQueryService.getActiveLayout(storeId);
+    @PreAuthorize("hasRole('OWNER')")
+    public ApiResponse<TableLayoutResDto.LayoutDetailDto> getActiveLayout(
+            @PathVariable Long storeId,
+            @CurrentUser User user
+            ) {
+        TableLayoutResDto.LayoutDetailDto result = tableLayoutQueryService.getActiveLayout(storeId, user.getUsername());
 
         if (result == null) {
             return ApiResponse.of(TableLayoutSuccessStatus._LAYOUT_NO_CONTENT, null);

--- a/src/main/java/com/eatsfine/eatsfine/domain/table_layout/controller/TableLayoutControllerDocs.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/table_layout/controller/TableLayoutControllerDocs.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.springframework.security.core.userdetails.User;
 
 public interface TableLayoutControllerDocs {
     @Operation(
@@ -28,7 +29,8 @@ public interface TableLayoutControllerDocs {
     ApiResponse<TableLayoutResDto.LayoutDetailDto> createLayout(
             @Parameter(description = "가게 ID", required = true, example = "1")
             Long storeId,
-            @RequestBody @Valid TableLayoutReqDto.LayoutCreateDto dto
+            @RequestBody @Valid TableLayoutReqDto.LayoutCreateDto dto,
+            @Parameter(hidden = true) User user
     );
 
     @Operation(
@@ -48,6 +50,7 @@ public interface TableLayoutControllerDocs {
     })
     ApiResponse<TableLayoutResDto.LayoutDetailDto> getActiveLayout(
             @Parameter(description = "가게 ID", required = true, example = "1")
-            Long storeId
+            Long storeId,
+            @Parameter(hidden = true) User user
     );
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/table_layout/service/TableLayoutCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/table_layout/service/TableLayoutCommandService.java
@@ -4,5 +4,5 @@ import com.eatsfine.eatsfine.domain.table_layout.dto.req.TableLayoutReqDto;
 import com.eatsfine.eatsfine.domain.table_layout.dto.res.TableLayoutResDto;
 
 public interface TableLayoutCommandService {
-    TableLayoutResDto.LayoutDetailDto createLayout(Long storeId, TableLayoutReqDto.LayoutCreateDto dto);
+    TableLayoutResDto.LayoutDetailDto createLayout(Long storeId, TableLayoutReqDto.LayoutCreateDto dto, String email);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/table_layout/service/TableLayoutCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/table_layout/service/TableLayoutCommandServiceImpl.java
@@ -4,6 +4,7 @@ import com.eatsfine.eatsfine.domain.store.entity.Store;
 import com.eatsfine.eatsfine.domain.store.exception.StoreException;
 import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
 import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
+import com.eatsfine.eatsfine.domain.store.validator.StoreValidator;
 import com.eatsfine.eatsfine.domain.table_layout.converter.TableLayoutConverter;
 import com.eatsfine.eatsfine.domain.table_layout.dto.req.TableLayoutReqDto;
 import com.eatsfine.eatsfine.domain.table_layout.dto.res.TableLayoutResDto;
@@ -19,12 +20,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class TableLayoutCommandServiceImpl implements TableLayoutCommandService {
     private final StoreRepository storeRepository;
     private final TableLayoutRepository tableLayoutRepository;
+    private final StoreValidator storeValidator;
 
     // 테이블 배치도 생성
     @Override
-    public TableLayoutResDto.LayoutDetailDto createLayout(Long storeId, TableLayoutReqDto.LayoutCreateDto dto) {
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+    public TableLayoutResDto.LayoutDetailDto createLayout(
+            Long storeId,
+            TableLayoutReqDto.LayoutCreateDto dto,
+            String email
+            ) {
+
+        Store store = storeValidator.validateStoreOwner(storeId, email);
 
         deactivateExistingLayout(store);
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/table_layout/service/TableLayoutQueryService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/table_layout/service/TableLayoutQueryService.java
@@ -3,5 +3,5 @@ package com.eatsfine.eatsfine.domain.table_layout.service;
 import com.eatsfine.eatsfine.domain.table_layout.dto.res.TableLayoutResDto;
 
 public interface TableLayoutQueryService {
-    TableLayoutResDto.LayoutDetailDto getActiveLayout(Long storeId);
+    TableLayoutResDto.LayoutDetailDto getActiveLayout(Long storeId, String email);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/table_layout/service/TableLayoutQueryServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/table_layout/service/TableLayoutQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.eatsfine.eatsfine.domain.table_layout.service;
 import com.eatsfine.eatsfine.domain.store.exception.StoreException;
 import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
 import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
+import com.eatsfine.eatsfine.domain.store.validator.StoreValidator;
 import com.eatsfine.eatsfine.domain.table_layout.converter.TableLayoutConverter;
 import com.eatsfine.eatsfine.domain.table_layout.dto.res.TableLayoutResDto;
 import com.eatsfine.eatsfine.domain.table_layout.repository.TableLayoutRepository;
@@ -16,12 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class TableLayoutQueryServiceImpl implements TableLayoutQueryService {
     private final StoreRepository storeRepository;
     private final TableLayoutRepository tableLayoutRepository;
+    private final StoreValidator storeValidator;
 
     // 테이블 배치도 조회
     @Override
-    public TableLayoutResDto.LayoutDetailDto getActiveLayout(Long storeId) {
-        storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+    public TableLayoutResDto.LayoutDetailDto getActiveLayout(Long storeId, String email) {
+
+        storeValidator.validateStoreOwner(storeId, email);
 
         // 배치도가 없을 시 null 반환
         return tableLayoutRepository.findByStoreIdAndIsActiveTrue(storeId)

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/controller/TableBlockController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/controller/TableBlockController.java
@@ -7,6 +7,7 @@ import com.eatsfine.eatsfine.domain.tableblock.service.TableBlockCommandService;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "TableBlock", description = "테이블 슬롯 차단/해제 API")
@@ -18,6 +19,7 @@ public class TableBlockController implements TableBlockControllerDocs {
 
     @Override
     @PatchMapping("/stores/{storeId}/tables/{tableId}/slots")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<TableBlockResDto.SlotStatusUpdateDto> updateSlotStatus(
             @PathVariable Long storeId,
             @PathVariable Long tableId,

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/controller/TableBlockController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/controller/TableBlockController.java
@@ -4,10 +4,12 @@ import com.eatsfine.eatsfine.domain.tableblock.dto.req.TableBlockReqDto;
 import com.eatsfine.eatsfine.domain.tableblock.dto.res.TableBlockResDto;
 import com.eatsfine.eatsfine.domain.tableblock.exception.status.TableBlockSuccessStatus;
 import com.eatsfine.eatsfine.domain.tableblock.service.TableBlockCommandService;
+import com.eatsfine.eatsfine.global.annotation.CurrentUser;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "TableBlock", description = "테이블 슬롯 차단/해제 API")
@@ -23,8 +25,9 @@ public class TableBlockController implements TableBlockControllerDocs {
     public ApiResponse<TableBlockResDto.SlotStatusUpdateDto> updateSlotStatus(
             @PathVariable Long storeId,
             @PathVariable Long tableId,
-            @RequestBody TableBlockReqDto.SlotStatusUpdateDto dto
-    ) {
-        return ApiResponse.of(TableBlockSuccessStatus._SLOT_STATUS_UPDATED, tableBlockCommandService.updateSlotStatus(storeId, tableId, dto));
+            @RequestBody TableBlockReqDto.SlotStatusUpdateDto dto,
+            @CurrentUser User user
+            ) {
+        return ApiResponse.of(TableBlockSuccessStatus._SLOT_STATUS_UPDATED, tableBlockCommandService.updateSlotStatus(storeId, tableId, dto, user.getUsername()));
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/controller/TableBlockControllerDocs.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/controller/TableBlockControllerDocs.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.RequestBody;
 
 public interface TableBlockControllerDocs {
@@ -31,6 +32,9 @@ public interface TableBlockControllerDocs {
             @Parameter(description = "테이블 ID", required = true, example = "1")
             Long tableId,
 
-            @RequestBody @Valid TableBlockReqDto.SlotStatusUpdateDto dto
+            @RequestBody @Valid TableBlockReqDto.SlotStatusUpdateDto dto,
+
+            @Parameter(hidden = true) User user
+
     );
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/service/TableBlockCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/service/TableBlockCommandService.java
@@ -4,5 +4,5 @@ import com.eatsfine.eatsfine.domain.tableblock.dto.req.TableBlockReqDto;
 import com.eatsfine.eatsfine.domain.tableblock.dto.res.TableBlockResDto;
 
 public interface TableBlockCommandService {
-    TableBlockResDto.SlotStatusUpdateDto updateSlotStatus(Long storeId, Long tableId, TableBlockReqDto.SlotStatusUpdateDto dto);
+    TableBlockResDto.SlotStatusUpdateDto updateSlotStatus(Long storeId, Long tableId, TableBlockReqDto.SlotStatusUpdateDto dto, String email);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableblock/service/TableBlockCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableblock/service/TableBlockCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.eatsfine.eatsfine.domain.store.entity.Store;
 import com.eatsfine.eatsfine.domain.store.exception.StoreException;
 import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
 import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
+import com.eatsfine.eatsfine.domain.store.validator.StoreValidator;
 import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
 import com.eatsfine.eatsfine.domain.storetable.exception.StoreTableException;
 import com.eatsfine.eatsfine.domain.storetable.exception.status.StoreTableErrorStatus;
@@ -34,12 +35,18 @@ public class TableBlockCommandServiceImpl implements TableBlockCommandService {
     private final TableBlockRepository tableBlockRepository;
     private final StoreRepository storeRepository;
     private final BookingRepository bookingRepository;
+    private final StoreValidator storeValidator;
 
     // 테이블 슬롯 상태 변경
     @Override
-    public TableBlockResDto.SlotStatusUpdateDto updateSlotStatus(Long storeId, Long tableId, TableBlockReqDto.SlotStatusUpdateDto dto) {
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+    public TableBlockResDto.SlotStatusUpdateDto updateSlotStatus(
+            Long storeId,
+            Long tableId,
+            TableBlockReqDto.SlotStatusUpdateDto dto,
+            String email
+            ) {
+
+        Store store = storeValidator.validateStoreOwner(storeId, email);
 
         StoreTable table = storeTableRepository.findById(tableId)
                 .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._TABLE_NOT_FOUND));

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/controller/TableImageController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/controller/TableImageController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -31,6 +32,7 @@ public class TableImageController {
             value = "/stores/{storeId}/table-images",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE
     )
+    @PreAuthorize("hasRole('OWNER')")
     ApiResponse<TableImageResDto.UploadTableImageDto> uploadTableImage(
             @RequestPart("file") List<MultipartFile> files,
             @PathVariable Long storeId
@@ -46,7 +48,7 @@ public class TableImageController {
             description = "식당 테이블 이미지들을 조회합니다."
     )
     @GetMapping("/stores/{storeId}/table-images")
-    ApiResponse<TableImageResDto.GetTableImageDto>  getTableImage(
+    ApiResponse<TableImageResDto.GetTableImageDto> getTableImage(
             @PathVariable Long storeId
     ) {
         return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_GET_SUCCESS, tableImageQueryService.getTableImage(storeId));
@@ -57,6 +59,7 @@ public class TableImageController {
             description = "식당 테이블 이미지를 삭제합니다."
     )
     @DeleteMapping("/stores/{storeId}/table-images")
+    @PreAuthorize("hasRole('OWNER')")
     ApiResponse<TableImageResDto.DeleteTableImageDto> deleteTableImage(
             @PathVariable Long storeId,
             @RequestBody List<Long> tableImageIds

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/controller/TableImageController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/controller/TableImageController.java
@@ -4,12 +4,14 @@ import com.eatsfine.eatsfine.domain.tableimage.dto.TableImageResDto;
 import com.eatsfine.eatsfine.domain.tableimage.service.TableImageCommandService;
 import com.eatsfine.eatsfine.domain.tableimage.service.TableImageQueryService;
 import com.eatsfine.eatsfine.domain.tableimage.status.TableImageSuccessStatus;
+import com.eatsfine.eatsfine.global.annotation.CurrentUser;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -35,11 +37,12 @@ public class TableImageController {
     @PreAuthorize("hasRole('OWNER')")
     ApiResponse<TableImageResDto.UploadTableImageDto> uploadTableImage(
             @RequestPart("file") List<MultipartFile> files,
-            @PathVariable Long storeId
-    ) {
+            @PathVariable Long storeId,
+            @CurrentUser User user
+            ) {
         return ApiResponse.of(
                 TableImageSuccessStatus._STORE_TABLE_IMAGE_UPLOAD_SUCCESS,
-                tableImageCommandService.uploadTableImage(storeId, files)
+                tableImageCommandService.uploadTableImage(storeId, files, user.getUsername())
         );
     }
 
@@ -62,9 +65,10 @@ public class TableImageController {
     @PreAuthorize("hasRole('OWNER')")
     ApiResponse<TableImageResDto.DeleteTableImageDto> deleteTableImage(
             @PathVariable Long storeId,
-            @RequestBody List<Long> tableImageIds
+            @RequestBody List<Long> tableImageIds,
+            @CurrentUser User user
     ) {
-        return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_DELETE_SUCCESS, tableImageCommandService.deleteTableImage(storeId, tableImageIds));
+        return ApiResponse.of(TableImageSuccessStatus._STORE_TABLE_IMAGE_DELETE_SUCCESS, tableImageCommandService.deleteTableImage(storeId, tableImageIds, user.getUsername()));
     }
 
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageCommandService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/tableimage/service/TableImageCommandService.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface TableImageCommandService {
 
-    TableImageResDto.UploadTableImageDto uploadTableImage(Long storeId, List<MultipartFile> files);
+    TableImageResDto.UploadTableImageDto uploadTableImage(Long storeId, List<MultipartFile> files, String email);
 
-    TableImageResDto.DeleteTableImageDto deleteTableImage(Long storeId, List<Long> tableImageIds);
+    TableImageResDto.DeleteTableImageDto deleteTableImage(Long storeId, List<Long> tableImageIds, String email);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/controller/UserController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/controller/UserController.java
@@ -78,8 +78,8 @@ public class UserController {
 
     @PatchMapping(value = "/api/v1/member/info")
     @Operation(
-            summary = "닉네임/전화번호 수정 API - 인증 필요",
-            description = "닉네임/전화번호만 수정합니다. (JSON)",
+            summary = "이름/전화번호 수정 API - 인증 필요",
+            description = "이름/전화번호만 수정합니다. (JSON)",
             security = {@SecurityRequirement(name = "JWT")}
     )
     public ResponseEntity<ApiResponse<String>> updateMyInfoText(

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/controller/UserController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.eatsfine.eatsfine.domain.user.dto.response.UserResponseDto;
 import com.eatsfine.eatsfine.domain.user.exception.UserException;
 import com.eatsfine.eatsfine.domain.user.service.UserService;
 import com.eatsfine.eatsfine.domain.user.status.UserErrorStatus;
+import com.eatsfine.eatsfine.domain.user.status.UserSuccessStatus;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import com.eatsfine.eatsfine.global.auth.AuthCookieProvider;
 import com.eatsfine.eatsfine.global.config.jwt.JwtTokenProvider;
@@ -102,6 +103,19 @@ public class UserController {
     ) {
         String result = userService.updateMemberInfo(null, profileImage, request);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+
+    @PatchMapping("/api/users/role/owner")
+    @Operation(
+            summary = "사장 인증 API - 인증 필요",
+            description = "사장 인증을 통해 사장 권한을 부여받습니다.",
+            security = {@SecurityRequirement(name = "JWT")}
+    )
+    public ApiResponse<UserResponseDto.VerifyOwnerDto> verifyOwner(
+            @RequestBody @Valid UserRequestDto.VerifyOwnerDto verifyOwnerDto,
+            HttpServletRequest request
+    ) {
+        return ApiResponse.of(UserSuccessStatus.OWNER_VERIFICATION_SUCCESS, userService.verifyOwner(verifyOwnerDto, request));
     }
 
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/converter/UserConverter.java
@@ -82,6 +82,12 @@ public class UserConverter {
                 .build();
     }
 
+    public static UserResponseDto.VerifyOwnerDto toVerifyOwnerResponse(User user) {
+        return UserResponseDto.VerifyOwnerDto.builder()
+                .userId(user.getId())
+                .build();
+    }
+
 
     /*
      소셜 유저 생성 (최초 소셜 가입 등)

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/converter/UserConverter.java
@@ -36,7 +36,7 @@ public class UserConverter {
                 .id(user.getId())
                 .profileImage(user.getProfileImage())
                 .email(user.getEmail())
-                .nickName(user.getNickName())
+                .name(user.getName())
                 .phoneNumber(user.getPhoneNumber())
                 .build();
     }
@@ -47,7 +47,7 @@ public class UserConverter {
         return UserResponseDto.UpdateResponseDto.builder()
                 .profileImage(user.getProfileImage())
                 .email(user.getEmail())
-                .nickName(user.getNickName())
+                .name(user.getName())
                 .phoneNumber(user.getPhoneNumber())
                 .build();
     }
@@ -65,7 +65,7 @@ public class UserConverter {
 
     public static User toUser(UserRequestDto.JoinDto dto, String encodedPassword) {
         return User.builder()
-                .nickName(dto.getNickName())
+                .name(dto.getName())
                 .email(dto.getEmail())
                 .phoneNumber(dto.getPhoneNumber())
                 .password(encodedPassword)
@@ -91,13 +91,13 @@ public class UserConverter {
 
     /*
      소셜 유저 생성 (최초 소셜 가입 등)
-     -소셜 로그인에서 email/nickname/phoneNumber 등을 확보한 후 엔티티 생성에 사용
+     -소셜 로그인에서 email/name/phoneNumber 등을 확보한 후 엔티티 생성에 사용
      */
-    public static User toSocialUser(String email, String nickName, String phoneNumber, String socialId, SocialType socialType) {
+    public static User toSocialUser(String email, String name, String phoneNumber, String socialId, SocialType socialType) {
 
         return User.builder()
                 .email(email)
-                .nickName(nickName)
+                .name(name)
                 .phoneNumber(phoneNumber)
                 .socialId(socialId)
                 .socialType(socialType)

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/dto/request/UserRequestDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/dto/request/UserRequestDto.java
@@ -14,7 +14,7 @@ public class UserRequestDto {
     public static class JoinDto{
 
         @NotBlank(message = "이름은 필수입니다.")
-        private String nickName;  // 이름
+        private String name;  // 이름
 
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "유효한 이메일 형식이어야 합니다.")
@@ -62,7 +62,7 @@ public class UserRequestDto {
     @Setter
     public static class UpdateDto {
         private String email;
-        private String nickName;
+        private String name;
         private String phoneNumber;
     }
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/dto/request/UserRequestDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/dto/request/UserRequestDto.java
@@ -98,7 +98,7 @@ public class UserRequestDto {
         private String businessNumber;
 
         @Schema(description = "개업일자", example = "20240101")
-        @NotBlank
+        @NotBlank(message = "개업일자는 필수입니다.")
         @Pattern(regexp = "^[0-9]{8}$", message = "개업일자는 YYYYMMDD 형식이어야 합니다.")
         private String startDate;
     }

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/dto/request/UserRequestDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/dto/request/UserRequestDto.java
@@ -3,6 +3,7 @@ package com.eatsfine.eatsfine.domain.user.dto.request;
 import com.eatsfine.eatsfine.global.validator.annotation.PasswordMatch;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -84,5 +85,20 @@ public class UserRequestDto {
         @NotBlank(message = "새 비밀번호 확인은 필수입니다.")
         @Schema(description = "새 비밀번호 확인", example = "NewPw!1234")
         private String newPasswordConfirm;
+    }
+
+    @Getter
+    @Builder
+    public static class VerifyOwnerDto {
+
+        @Schema(description = "사업자번호", example = "1234567890")
+        @NotBlank(message = "사업자번호는 필수입니다.")
+        @Pattern(regexp = "^[0-9]{10}$", message = "사업자번호는 숫자 10자리여야 합니다.")
+        private String businessNumber;
+
+        @Schema(description = "개업일자", example = "20240101")
+        @NotBlank
+        @Pattern(regexp = "^[0-9]{8}$", message = "개업일자는 YYYYMMDD 형식이어야 합니다.")
+        private String startDate;
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/dto/request/UserRequestDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/dto/request/UserRequestDto.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class UserRequestDto {
@@ -88,7 +89,7 @@ public class UserRequestDto {
     }
 
     @Getter
-    @Builder
+    @NoArgsConstructor
     public static class VerifyOwnerDto {
 
         @Schema(description = "사업자번호", example = "1234567890")

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/dto/request/UserRequestDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/dto/request/UserRequestDto.java
@@ -3,7 +3,6 @@ package com.eatsfine.eatsfine.domain.user.dto.request;
 import com.eatsfine.eatsfine.global.validator.annotation.PasswordMatch;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/dto/response/UserResponseDto.java
@@ -36,7 +36,7 @@ public class UserResponseDto {
         private Long id;
         private String profileImage;
         private String email;
-        private String nickName;
+        private String name;
         private String phoneNumber;
     }
 
@@ -46,7 +46,7 @@ public class UserResponseDto {
     public static class UpdateResponseDto{
         private String profileImage;
         private String email;
-        private String nickName;
+        private String name;
         private String phoneNumber;
     }
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/dto/response/UserResponseDto.java
@@ -1,6 +1,8 @@
 package com.eatsfine.eatsfine.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -61,6 +63,13 @@ public class UserResponseDto {
 
         @Schema(description = "응답 메시지", example = "비밀번호가 성공적으로 변경되었습니다.")
         private String message;
+    }
+
+    @Getter
+    @Builder
+    public static class VerifyOwnerDto {
+        @Schema(description = "권한 승격이 완료된 유저의 식별자", example = "1")
+        private Long userId;
     }
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/entity/User.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/entity/User.java
@@ -48,7 +48,7 @@ public class User extends BaseEntity {
     @Column(length = 500)
     private String refreshToken;
 
-    public void updatename(String name){
+    public void updateName(String name){
         this.name = name;
     }
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/entity/User.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/entity/User.java
@@ -22,7 +22,7 @@ public class User extends BaseEntity {
     private Long id;
 
     @Column(nullable = false, length = 20)
-    private String nickName;
+    private String name;
 
     @Column(nullable = false, unique = true)
     private String email;
@@ -48,8 +48,8 @@ public class User extends BaseEntity {
     @Column(length = 500)
     private String refreshToken;
 
-    public void updateNickname(String nickName){
-        this.nickName = nickName;
+    public void updatename(String name){
+        this.name = name;
     }
 
     public void updatePhoneNumber(String phoneNumber) {

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/entity/User.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/entity/User.java
@@ -66,5 +66,7 @@ public class User extends BaseEntity {
         this.role = Role.ROLE_OWNER;
     }
 
-    public void updateRefreshToken(String refreshToken){this.refreshToken = refreshToken;}
+    public void updateRefreshToken(String refreshToken){
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/entity/User.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/entity/User.java
@@ -2,6 +2,8 @@ package com.eatsfine.eatsfine.domain.user.entity;
 
 import com.eatsfine.eatsfine.domain.user.enums.Role;
 import com.eatsfine.eatsfine.domain.user.enums.SocialType;
+import com.eatsfine.eatsfine.domain.user.exception.UserException;
+import com.eatsfine.eatsfine.domain.user.status.UserErrorStatus;
 import com.eatsfine.eatsfine.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -60,6 +62,10 @@ public class User extends BaseEntity {
 
     public void updateProfileImage(String profileImage) {
         this.profileImage = profileImage;
+    }
+
+    public void updateToOwner() {
+        this.role = Role.ROLE_OWNER;
     }
 
     public void updateRefreshToken(String refreshToken){this.refreshToken = refreshToken;}

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/entity/User.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/entity/User.java
@@ -2,8 +2,6 @@ package com.eatsfine.eatsfine.domain.user.entity;
 
 import com.eatsfine.eatsfine.domain.user.enums.Role;
 import com.eatsfine.eatsfine.domain.user.enums.SocialType;
-import com.eatsfine.eatsfine.domain.user.exception.UserException;
-import com.eatsfine.eatsfine.domain.user.status.UserErrorStatus;
 import com.eatsfine.eatsfine.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/entity/User.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/entity/User.java
@@ -46,7 +46,7 @@ public class User extends BaseEntity {
     @Column(length = 500)
     private String refreshToken;
 
-    public void updateName(String name){
+    public void updateName(String name) {
         this.name = name;
     }
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/service/UserService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/service/UserService.java
@@ -21,4 +21,6 @@ public interface UserService {
 
     void logout(HttpServletRequest request);
 
+    UserResponseDto.VerifyOwnerDto verifyOwner(UserRequestDto.VerifyOwnerDto verifyOwnerDto, HttpServletRequest request);
+
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/service/UserServiceImpl.java
@@ -226,8 +226,8 @@ public class UserServiceImpl implements UserService{
     @Transactional
     public UserResponseDto.VerifyOwnerDto verifyOwner(UserRequestDto.VerifyOwnerDto dto, HttpServletRequest request) {
         User user = getCurrentUser(request);
-        log.info("[OwnerAuth] 사장 인증 시도 - 유저ID: {}, 이메일: {}, 사업자번호: {}",
-                user.getId(), user.getEmail(), dto.getBusinessNumber());
+        log.info("[OwnerAuth] 사장 인증 시도 - 유저ID: {}, 이메일: {}",
+                user.getId(), user.getEmail());
 
         if (user.getRole() == Role.ROLE_OWNER) {
             log.warn("[OwnerAuth] 인증 실패 - 이미 사장 권한을 가진 유저입니다. 유저ID: {}", user.getId());

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/service/UserServiceImpl.java
@@ -69,7 +69,7 @@ public class UserServiceImpl implements UserService{
         }
 
         // 3) 토큰 발급
-        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail());
+        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getRole().name());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail());
 
         // 4) refreshToken 저장

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/service/UserServiceImpl.java
@@ -101,7 +101,7 @@ public class UserServiceImpl implements UserService{
 
         // 이름/전화번호 부분 수정
         if (updateDto.getName() != null && !updateDto.getName().isBlank()) {
-            user.updatename(updateDto.getName());
+            user.updateName(updateDto.getName());
             changed = true;
         }
         if (updateDto.getPhoneNumber() != null && !updateDto.getPhoneNumber().isBlank()) {

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/service/UserServiceImpl.java
@@ -99,9 +99,9 @@ public class UserServiceImpl implements UserService{
 
         boolean changed = false;
 
-        //닉네임/전화번호 부분 수정
-        if (updateDto.getNickName() != null && !updateDto.getNickName().isBlank()) {
-            user.updateNickname(updateDto.getNickName());
+        // 이름/전화번호 부분 수정
+        if (updateDto.getName() != null && !updateDto.getName().isBlank()) {
+            user.updatename(updateDto.getName());
             changed = true;
         }
         if (updateDto.getPhoneNumber() != null && !updateDto.getPhoneNumber().isBlank()) {
@@ -161,9 +161,9 @@ public class UserServiceImpl implements UserService{
         userRepository.save(user);
         userRepository.flush();
 
-        log.info("[Service] Updated userId={}, nickname={}, phone={}, profileKey={}",
+        log.info("[Service] Updated userId={}, name={}, phone={}, profileKey={}",
                 user.getId(),
-                user.getNickName(),
+                user.getName(),
                 user.getPhoneNumber(),
                 user.getProfileImage());
 
@@ -234,7 +234,7 @@ public class UserServiceImpl implements UserService{
             throw new UserException(UserErrorStatus.ALREADY_OWNER);
         }
 
-        businessNumberValidator.validate(dto.getBusinessNumber(), dto.getStartDate(), user.getNickName());
+        businessNumberValidator.validate(dto.getBusinessNumber(), dto.getStartDate(), user.getName());
 
         user.updateToOwner();
         User savedUser = userRepository.save(user);

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/status/UserErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/status/UserErrorStatus.java
@@ -19,8 +19,11 @@ public enum UserErrorStatus implements BaseErrorCode {
     // 토큰 관련 에러
     INVALID_TOKEN(HttpStatus.NOT_FOUND, "TOKEN4001", "토큰이 없습니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4002", "토큰이 만료되었습니다."),
-    REFRESH_TOKEN_NOT_ISSUED(HttpStatus.INTERNAL_SERVER_ERROR, "TOKEN5001", "리프레시 토큰이 발급되지 않았습니다.");
+    REFRESH_TOKEN_NOT_ISSUED(HttpStatus.INTERNAL_SERVER_ERROR, "TOKEN5001", "리프레시 토큰이 발급되지 않았습니다."),
 
+    // 사장 인증 관련 에러
+    ALREADY_OWNER(HttpStatus.CONFLICT, "OWNER409", "이미 사장 회원입니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;
@@ -45,7 +48,4 @@ public enum UserErrorStatus implements BaseErrorCode {
                 .build();
     }
 
-
-
-
-    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/status/UserErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/status/UserErrorStatus.java
@@ -20,7 +20,7 @@ public enum UserErrorStatus implements BaseErrorCode {
     INVALID_TOKEN(HttpStatus.NOT_FOUND, "TOKEN4001", "토큰이 없습니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4002", "토큰이 만료되었습니다."),
     REFRESH_TOKEN_NOT_ISSUED(HttpStatus.INTERNAL_SERVER_ERROR, "TOKEN5001", "리프레시 토큰이 발급되지 않았습니다."),
-
+    EMPTY_TOKEN_ROLE(HttpStatus.UNAUTHORIZED, "AUTH401", "토큰 내 권한 정보가 누락되었습니다."),
     // 사장 인증 관련 에러
     ALREADY_OWNER(HttpStatus.CONFLICT, "OWNER409", "이미 사장 회원입니다."),
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/status/UserErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/status/UserErrorStatus.java
@@ -12,7 +12,7 @@ public enum UserErrorStatus implements BaseErrorCode {
 
     // 멤버 관련 에러
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
-    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
+    NAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "이름은 필수 입니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER4003", "이미 존재하는 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER4004", "비밀번호가 올바르지 않습니다."),
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/status/UserErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/status/UserErrorStatus.java
@@ -23,6 +23,9 @@ public enum UserErrorStatus implements BaseErrorCode {
 
     // 사장 인증 관련 에러
     ALREADY_OWNER(HttpStatus.CONFLICT, "OWNER409", "이미 사장 회원입니다."),
+
+    // 사장 전용 API 접근 관련 에러
+    FORBIDDEN_OWNER(HttpStatus.FORBIDDEN, "AUTH403", "사장님 권한이 필요한 서비스입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/eatsfine/eatsfine/domain/user/status/UserSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/user/status/UserSuccessStatus.java
@@ -1,0 +1,40 @@
+package com.eatsfine.eatsfine.domain.user.status;
+
+import com.eatsfine.eatsfine.global.apiPayload.code.BaseCode;
+import com.eatsfine.eatsfine.global.apiPayload.code.ErrorReasonDto;
+import com.eatsfine.eatsfine.global.apiPayload.code.ReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserSuccessStatus implements BaseCode {
+
+    OWNER_VERIFICATION_SUCCESS(HttpStatus.OK, "OWNER2001", "사장 인증 성공"),
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDto getReason() {
+        return ReasonDto.builder()
+                .isSuccess(true)
+                .message(message)
+                .code(code)
+                .build();
+    }
+
+    @Override
+    public ReasonDto getReasonHttpStatus() {
+        return ReasonDto.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(true)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/global/annotation/CurrentUser.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/annotation/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.eatsfine.eatsfine.global.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : principal")
+public @interface CurrentUser {
+}

--- a/src/main/java/com/eatsfine/eatsfine/global/annotation/CurrentUser.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/annotation/CurrentUser.java
@@ -9,6 +9,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : principal")
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this")
 public @interface CurrentUser {
 }

--- a/src/main/java/com/eatsfine/eatsfine/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -70,7 +70,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
                 HttpHeaders.EMPTY,
                 UserErrorStatus.FORBIDDEN_OWNER.getHttpStatus(),
                 request,
-                e.getMessage()
+                null
         );
     }
 

--- a/src/main/java/com/eatsfine/eatsfine/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -1,5 +1,6 @@
 package com.eatsfine.eatsfine.global.apiPayload.handler;
 
+import com.eatsfine.eatsfine.domain.user.status.UserErrorStatus;
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import com.eatsfine.eatsfine.global.apiPayload.code.BaseErrorCode;
 import com.eatsfine.eatsfine.global.apiPayload.code.status.ErrorStatus;
@@ -10,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -54,6 +56,22 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
         // 첫 번째 에러 메시지만 추출
         String errorMessage = e.getConstraintViolations().iterator().next().getMessage();
         return handleExceptionInternalFalse(e, ErrorStatus._BAD_REQUEST, HttpHeaders.EMPTY, ErrorStatus._BAD_REQUEST.getHttpStatus(), request, errorMessage);
+    }
+
+    // @PreAuthorize 권한 실패 시 발생하는 예외 캐치
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException e, WebRequest request) {
+        log.warn("Access Denied: {}", e.getMessage());
+
+        // 2. 기존 메서드를 활용해 ResponseEntity<Object>로 반환
+        return handleExceptionInternalFalse(
+                e,
+                UserErrorStatus.FORBIDDEN_OWNER,
+                HttpHeaders.EMPTY,
+                UserErrorStatus.FORBIDDEN_OWNER.getHttpStatus(),
+                request,
+                e.getMessage()
+        );
     }
 
     // 3. 커스텀 예외용 내부 응답 생성 메서드

--- a/src/main/java/com/eatsfine/eatsfine/global/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/auth/UserDetailsServiceImpl.java
@@ -5,6 +5,7 @@ package com.eatsfine.eatsfine.global.auth;
 
 import com.eatsfine.eatsfine.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -28,7 +29,11 @@ public class UserDetailsServiceImpl implements UserDetailsService {
             throw new UsernameNotFoundException("비밀번호 기반 로그인 대상이 아닙니다.");
         }
 
-        return new User(user.getEmail(), password, List.of());
+        return new User(
+                user.getEmail(),
+                password,
+                List.of(new SimpleGrantedAuthority(user.getRole().name()))
+        );
     }
 }
 

--- a/src/main/java/com/eatsfine/eatsfine/global/config/SecurityConfig.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                         // 공개 리소스 / 인증 없이
                         .requestMatchers(
                                 "/api/auth/**",
+                                "/oauth2/**",
                                 "/swagger-ui.html",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",

--- a/src/main/java/com/eatsfine/eatsfine/global/config/SecurityConfig.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpMethod;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -26,6 +27,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/com/eatsfine/eatsfine/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/config/jwt/JwtAuthenticationFilter.java
@@ -5,11 +5,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -18,10 +17,10 @@ import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final UserDetailsService userDetailsService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -30,22 +29,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
 
         String uri = request.getRequestURI();
-        System.out.println("요청 URI: " + uri);
-
-        // 인증 없이 통과시킬 경로들
-        if (uri.startsWith("/api/auth/login") ||
-                uri.startsWith("/api/auth/signup") ||
-                uri.startsWith("/oauth2") ||
-                uri.startsWith("/login")) {
-            chain.doFilter(request, response);
-            return;
-        }
-
+        log.debug("요청 URI: " + uri);
 
         String token = JwtTokenProvider.resolveToken(request);
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
             try {
+
+                // uri.startsWith() 로직 삭제
+                // 토큰이 없으면 아래 if문에서 알아서 걸러지고 다음 필터로 넘어감.
+                // -> SecurityConfig의 permitAll() 설정에 따라 통과 여부 결정
 
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
 
@@ -57,7 +50,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (Exception e) {
                 // 예외 로그 출력
-                System.out.println("JWT 인증 오류: " + e.getMessage());
+                log.warn("JWT 인증 오류: " + e.getMessage());
             }
         }
 

--- a/src/main/java/com/eatsfine/eatsfine/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/config/jwt/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -45,13 +46,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
             try {
-                String email = jwtTokenProvider.getEmailFromToken(token);
-                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
 
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(
-                                userDetails, null, userDetails.getAuthorities());
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
+                if(authentication instanceof UsernamePasswordAuthenticationToken) {
+                    ((UsernamePasswordAuthenticationToken) authentication)
+                            .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                }
+
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (Exception e) {
                 // 예외 로그 출력

--- a/src/main/java/com/eatsfine/eatsfine/global/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/config/jwt/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.eatsfine.eatsfine.global.config.jwt;
 import com.eatsfine.eatsfine.domain.user.exception.UserException;
 import com.eatsfine.eatsfine.domain.user.status.UserErrorStatus;
 import com.eatsfine.eatsfine.global.config.properties.Constants;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import com.eatsfine.eatsfine.global.apiPayload.code.status.ErrorStatus;
 import com.eatsfine.eatsfine.global.config.properties.JwtProperties;
@@ -20,8 +21,10 @@ import org.springframework.util.StringUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -36,11 +39,14 @@ public class JwtTokenProvider {
     private final long accessTokenValidity = 1000L * 60 * 60; // 1시간
     private final long refreshTokenValidity = 1000L * 60 * 60 * 24 * 7; // 7일
 
-    public String createAccessToken(String email) {
+    public String createAccessToken(String email, String role) {
+        Claims claims = Jwts.claims().setSubject(email);
+        claims.put("role", role);
+
         Date now = new Date();
         Date expiry = new Date(now.getTime() + accessTokenValidity);
         return Jwts.builder()
-                .setSubject(email)
+                .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(expiry)
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
@@ -79,7 +85,11 @@ public class JwtTokenProvider {
 
         String email = claims.getSubject();
 
-        User principal = new User(email, "", Collections.emptyList());
+        String role = claims.get("role", String.class);
+
+        List<SimpleGrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(role));
+
+        User principal = new User(email, "", authorities);
         return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
     }
 

--- a/src/main/java/com/eatsfine/eatsfine/global/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/config/jwt/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.eatsfine.eatsfine.global.config.jwt;
 import com.eatsfine.eatsfine.domain.user.exception.UserException;
 import com.eatsfine.eatsfine.domain.user.status.UserErrorStatus;
 import com.eatsfine.eatsfine.global.config.properties.Constants;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import com.eatsfine.eatsfine.global.apiPayload.code.status.ErrorStatus;
@@ -28,6 +29,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtTokenProvider {
 
     private final JwtProperties jwtProperties;
@@ -40,6 +42,10 @@ public class JwtTokenProvider {
     private final long refreshTokenValidity = 1000L * 60 * 60 * 24 * 7; // 7일
 
     public String createAccessToken(String email, String role) {
+        if (!StringUtils.hasText(role)) {
+            throw new UserException(UserErrorStatus.EMPTY_TOKEN_ROLE);
+        }
+
         Claims claims = Jwts.claims().setSubject(email);
         claims.put("role", role);
 
@@ -86,6 +92,11 @@ public class JwtTokenProvider {
         String email = claims.getSubject();
 
         String role = claims.get("role", String.class);
+
+        if (!StringUtils.hasText(role)) {
+            log.error("JWT Token does not contain role claim for user: {}", claims.getSubject());
+            throw new UserException(UserErrorStatus.EMPTY_TOKEN_ROLE);
+        }
 
         List<SimpleGrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(role));
 


### PR DESCRIPTION
### 💡 작업 개요

**- 아래 API들에 사장 권한 검증, 본인 가게 여부 검증부 추가했습니다.** 

1. BusinessHours (영업시간 관리)
* 영업시간 수정: PATCH /api/v1/stores/{storeId}/business-hours
* 브레이크타임 설정: PATCH /api/v1/stores/{storeId}/break-time
2. Menu (메뉴 관리)
* 메뉴 이미지 선 업로드: POST /api/v1/stores/{storeId}/menus/images
* 메뉴 등록: POST /api/v1/stores/{storeId}/menus
* 메뉴 삭제: DELETE /api/v1/stores/{storeId}/menus
* 메뉴 수정: PATCH /api/v1/stores/{storeId}/menus/{menuId}
* 품절 여부 변경: PATCH /api/v1/stores/{storeId}/menus/{menuId}/sold-out
* 메뉴 이미지 삭제: DELETE /api/v1/stores/{storeId}/menus/{menuId}/image
3. Store (식당 기본 정보 관리)
* 식당 등록: POST /api/v1/stores
* 가게 기본 정보 수정: PATCH /api/v1/stores/{storeId}
* 식당 대표 이미지 등록: POST /api/v1/stores/{storeId}/main-image
4. StoreTable (테이블 관리)
* 테이블 생성: POST /api/v1/stores/{storeId}/tables
* 테이블 이미지 임시 업로드: POST /api/v1/stores/{storeId}/tables/images
* 테이블 정보 수정: PATCH /api/v1/stores/{storeId}/tables/{tableId}
* 테이블 삭제: DELETE /api/v1/stores/{storeId}/tables/{tableId}
* 테이블 개별 이미지 등록: POST /api/v1/stores/{storeId}/tables/{tableId}/table-image
* 테이블 개별 이미지 삭제: DELETE /api/v1/stores/{storeId}/tables/{tableId}/table-image
5. TableLayout & Block (배치도 및 슬롯 관리)
* 배치도 생성: POST /api/v1/stores/{storeId}/layouts
* 배치도 조회: GET /api/v1/stores/{storeId}/layouts
* 테이블 슬롯 상태 변경(차단/해제): PATCH /api/v1/stores/{storeId}/tables/{tableId}/slots
6. TableImage (테이블 전체 이미지 관리)
* 식당 테이블 이미지 일괄 등록: POST /api/v1/stores/{storeId}/table-images
* 식당 테이블 이미지 일괄 삭제: DELETE /api/v1/stores/{storeId}/table-images

**- 사장 인증 API (api/users/role/owner) 구현했습니다.** 
  사업자번호 검증 후 사장으로 권한 승격됩니다.
  ⚠️ 로그아웃 후, 재로그인해야 토큰에 권한이 정상 반영됩니다!!

**- User 엔티티의 'nickname' -> 'name' 필드명 변경했습니다.**

### ✅ 작업 내용
- [x] 기능 개발
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

### 🧪 테스트 내용
**- 일반 손님 권한(ROLE_CUSTOMER)일 때**

<img width="810" height="244" alt="스크린샷 2026-02-06 오전 1 08 38" src="https://github.com/user-attachments/assets/c9cb8a58-f163-4e9a-9e0c-04c9b4693fb0" />

**- 사장 권한(ROLE_OWNER)일 때**
<img width="820" height="256" alt="스크린샷 2026-02-06 오전 1 29 09" src="https://github.com/user-attachments/assets/13859e44-fe2c-4f90-8e45-a0f75e8df4f6" />



### 📝 기타 참고 사항
- ⚠️ 로그아웃 후, 재로그인해야 토큰에 권한 상승이 정상 반영됩니다!!

Closes #101 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사장 인증 API 추가로 사업자번호·개설일자 기반 사장 권한 획득 가능  
  * 현재 사용자 주입용 @CurrentUser 애노테이션 추가

* **보안**
  * 메뉴/영업시간/매장/테이블/이미지 등 수정 API에 사장(OWNER) 권한 강제 적용  
  * 토큰에 역할 포함 및 메서드 수준 권한검증 활성화

* **개선**
  * 페이지네이션에 isFirst/isLast 필드 추가  
  * 사용자 속성 '닉네임' → '이름'으로 변경  
  * 가게 소유권 검증 로직 통일 및 오류 상태 정리  
  * 이미지 삭제 등 일부 정리작업을 트랜잭션 후속 처리로 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->