### PR TITLE
[FEAT]: 내 가게 관리 페이지 조회 API에 사장 권한 RBAC 적용

### DIFF
--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableController.java
@@ -50,23 +50,27 @@ public class StoreTableController implements StoreTableControllerDocs {
     }
 
     @GetMapping("/stores/{storeId}/tables/{tableId}/slots")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreTableResDto.SlotListDto> getTableSlots(
             @PathVariable Long storeId,
             @PathVariable Long tableId,
-            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
+            @CurrentUser User user
     ) {
         LocalDate targetDate = (date != null) ? date : LocalDate.now();
-        return ApiResponse.of(StoreTableSuccessStatus._SLOT_LIST_FOUND, storeTableQueryService.getTableSlots(storeId, tableId, targetDate));
+        return ApiResponse.of(StoreTableSuccessStatus._SLOT_LIST_FOUND, storeTableQueryService.getTableSlots(storeId, tableId, targetDate, user.getUsername()));
     }
 
     @GetMapping("/stores/{storeId}/tables/{tableId}")
+    @PreAuthorize("hasRole('OWNER')")
     public ApiResponse<StoreTableResDto.TableDetailDto> getTableDetail(
             @PathVariable Long storeId,
             @PathVariable Long tableId,
-            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
+            @CurrentUser User user
     ) {
         LocalDate targetDate = (date != null) ? date : LocalDate.now();
-        return ApiResponse.of(StoreTableSuccessStatus._TABLE_DETAIL_FOUND, storeTableQueryService.getTableDetail(storeId, tableId, targetDate));
+        return ApiResponse.of(StoreTableSuccessStatus._TABLE_DETAIL_FOUND, storeTableQueryService.getTableDetail(storeId, tableId, targetDate, user.getUsername()));
     }
 
     @PatchMapping("/stores/{storeId}/tables/{tableId}")

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/controller/StoreTableControllerDocs.java
@@ -102,7 +102,9 @@ public interface StoreTableControllerDocs {
             Long tableId,
 
             @Parameter(description = "조회할 날짜 (yyyy-MM-dd 형식, 미입력 시 오늘 날짜)", example = "2026-01-12")
-            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date,
+
+            @Parameter(hidden = true) User user
     );
 
     @Operation(
@@ -127,7 +129,9 @@ public interface StoreTableControllerDocs {
             Long tableId,
 
             @Parameter(description = "조회 날짜 (yyyy-MM-dd)", example = "2026-01-23")
-            LocalDate date
+            LocalDate date,
+
+            @Parameter(hidden = true) User user
     );
 
     @Operation(

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryService.java
@@ -5,7 +5,7 @@ import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
 import java.time.LocalDate;
 
 public interface StoreTableQueryService {
-    StoreTableResDto.SlotListDto getTableSlots(Long storeId, Long tableId, LocalDate date);
+    StoreTableResDto.SlotListDto getTableSlots(Long storeId, Long tableId, LocalDate date, String email);
 
-    StoreTableResDto.TableDetailDto getTableDetail(Long storeId, Long tableId, LocalDate targetDate);
+    StoreTableResDto.TableDetailDto getTableDetail(Long storeId, Long tableId, LocalDate targetDate, String email);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/storetable/service/StoreTableQueryServiceImpl.java
@@ -4,6 +4,7 @@ import com.eatsfine.eatsfine.domain.booking.repository.BookingRepository;
 import com.eatsfine.eatsfine.domain.store.exception.StoreException;
 import com.eatsfine.eatsfine.domain.store.repository.StoreRepository;
 import com.eatsfine.eatsfine.domain.store.status.StoreErrorStatus;
+import com.eatsfine.eatsfine.domain.store.validator.StoreValidator;
 import com.eatsfine.eatsfine.domain.storetable.converter.StoreTableConverter;
 import com.eatsfine.eatsfine.domain.storetable.dto.res.StoreTableResDto;
 import com.eatsfine.eatsfine.domain.storetable.entity.StoreTable;
@@ -34,12 +35,13 @@ public class StoreTableQueryServiceImpl implements StoreTableQueryService{
     private final TableBlockRepository tableBlockRepository;
     private final BookingRepository bookingRepository;
     private final S3Service s3Service;
+    private final StoreValidator storeValidator;
 
     // 테이블 슬롯 조회
     @Override
-    public StoreTableResDto.SlotListDto getTableSlots(Long storeId, Long tableId, LocalDate date) {
-        storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+    public StoreTableResDto.SlotListDto getTableSlots(Long storeId, Long tableId, LocalDate date, String email) {
+
+        storeValidator.validateStoreOwner(storeId, email);
 
         StoreTable storeTable = storeTableRepository.findById(tableId)
                 .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._TABLE_NOT_FOUND));
@@ -61,9 +63,9 @@ public class StoreTableQueryServiceImpl implements StoreTableQueryService{
 
     // 테이블 상세 조회
     @Override
-    public StoreTableResDto.TableDetailDto getTableDetail(Long storeId, Long tableId, LocalDate targetDate) {
-        storeRepository.findById(storeId)
-                .orElseThrow(() -> new StoreException(StoreErrorStatus._STORE_NOT_FOUND));
+    public StoreTableResDto.TableDetailDto getTableDetail(Long storeId, Long tableId, LocalDate targetDate, String email) {
+
+        storeValidator.validateStoreOwner(storeId, email);
 
         StoreTable storeTable = storeTableRepository.findById(tableId)
                 .orElseThrow(() -> new StoreTableException(StoreTableErrorStatus._TABLE_NOT_FOUND));


### PR DESCRIPTION
### 💡 작업 개요
- 내 가게 관리 페이지(사장 대시보드)에서 사용되는 조회 API에 사장 접근 권한을 적용했습니다.
- 적용된 API: 테이블 상세 조회, 테이블 예약 시간대 조회
- `@PreAuthorize("hasRole('OWNER')")`로 호출 전에 사용자가 OWNER인지 검증
- 서비스 로직에서 가게 소유권 검증 로직을 추가하여 현재 로그인한 사용자의 이메일 = 가게 주인의 이메일을 비교

### ✅ 작업 내용
- [x] 기능 개발
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

### 🧪 테스트 내용
#### 1. **ROLE_CUSTOMER 계정으로 로그인 후 테이블 상세 조회 시 결과**
<img width="1404" height="622" alt="스크린샷 2026-02-07 145811" src="https://github.com/user-attachments/assets/35aa1a60-e04e-4b6d-9d71-b31110fb4975" />

### 📝 기타 참고 사항
- Closes #114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 테이블 슬롯 조회 및 테이블 상세 조회 API에 접근 제어 로직 추가
  * 서비스 계층에 사용자 검증 프로세스 통합
  * API 문서 업데이트로 인한 메서드 시그니처 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->