### PR TITLE
[FEAT]: Store, StoreTable 도메인 전체 접근 허용 URI 설정

### DIFF
--- a/src/main/java/com/eatsfine/eatsfine/global/config/SecurityConfig.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/config/SecurityConfig.java
@@ -68,13 +68,12 @@ public class SecurityConfig {
                                 "/swagger-resources/**"
                         ).permitAll()
 
-                        .requestMatchers("/auth/**", "/login/**", "/signup").permitAll()
                         .requestMatchers(HttpMethod.GET,
                                 "/api/v1/stores/search", // 식당 검색
-                                "/api/v1/stores/{storeId}", //식당 상세 조회
-                                "/api/v1/stores/{storeId}/main-image", // 식당 대표 이미지 조회
-                                "/api/v1/stores/{storeId}/menus", // 식당 메뉴 조회
-                                "/api/v1/stores/{storeId}/table-images" // 식당 테이블 이미지(가게 전경) 조회
+                                "/api/v1/stores/*", //식당 상세 조회
+                                "/api/v1/stores/*/main-image", // 식당 대표 이미지 조회
+                                "/api/v1/stores/*/menus", // 식당 메뉴 조회
+                                "/api/v1/stores/*/table-images" // 식당 테이블 이미지(가게 전경) 조회
                         ).permitAll()
 
                         .requestMatchers("/auth/**", "/login", "/signup").permitAll()

--- a/src/main/java/com/eatsfine/eatsfine/global/config/SecurityConfig.java
+++ b/src/main/java/com/eatsfine/eatsfine/global/config/SecurityConfig.java
@@ -69,6 +69,17 @@ public class SecurityConfig {
                         ).permitAll()
 
                         .requestMatchers("/auth/**", "/login/**", "/signup").permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/v1/stores/search", // 식당 검색
+                                "/api/v1/stores/{storeId}", //식당 상세 조회
+                                "/api/v1/stores/{storeId}/main-image", // 식당 대표 이미지 조회
+                                "/api/v1/stores/{storeId}/menus", // 식당 메뉴 조회
+                                "/api/v1/stores/{storeId}/table-images" // 식당 테이블 이미지(가게 전경) 조회
+                        ).permitAll()
+
+                        .requestMatchers("/auth/**", "/login", "/signup").permitAll()
+
+                        // 그 외는 인증 필요
                         .anyRequest().authenticated()
                 )
 


### PR DESCRIPTION
### 💡 작업 개요
- 비로그인자도 접근 가능한 URI 설정

"/api/v1/stores/search" // 식당 검색

"/api/v1/stores/{storeId}" //식당 상세 조회

"/api/v1/stores/{storeId}/main-image" // 식당 대표 이미지 조회

"/api/v1/stores/{storeId}/table-images" // 식당 테이블 이미지(가게 전경) 조회

"/api/v1/stores/{storeId}/menus" // 식당 메뉴 조회

### ✅ 작업 내용
- [x] 기능 개발
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

### 🧪 테스트 내용
- 로컬에서 빌드 성공

### 📝 기타 참고 사항
Closes #105 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **공개 API 접근 권한**
  * 매장 검색을 포함한 다양한 매장 관련 정보(검색, 상세, 메인 이미지, 메뉴, 테이블 이미지)를 로그인 없이 조회할 수 있습니다.
  * 기존 공개 엔드포인트(인증/로그인/회원가입 관련)는 계속 공개되어 있습니다.
  * 그 외 민감한 기능은 인증이 필요하도록 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->