### PR TITLE
[FEATURE]: 가게 심야 영업 허용 및 예약-브레이크타임 충돌 방어 로직 구현

### DIFF
--- a/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
@@ -89,9 +89,11 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
             "and b.status IN (com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.CONFIRMED, com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.PENDING) " +
             "and b.bookingDate >= CURRENT_DATE " +
             "and (" +
-            "   (b.bookingTime >= :breakStart and b.bookingTime < :breakEnd) " + // 케이스 A: 브레이크 중에 예약 시작
+            "   (b.bookingTime >= :breakStart and b.bookingTime < :breakEnd) " + // 1. 브레이크 타임 내 시작
             "   OR " +
-            "   (b.bookingTime >= :adjustedBreakStart and b.bookingTime < :breakStart)" + // 케이스 B: 브레이크 전에 시작해서 걸침
+            "   (:adjustedBreakStart < :breakStart and b.bookingTime >= :adjustedBreakStart and b.bookingTime < :breakStart) " + // 2. 일반적인 경우 (낮)
+            "   OR " +
+            "   (:adjustedBreakStart > :breakStart and (b.bookingTime >= :adjustedBreakStart or b.bookingTime < :breakStart)) " + // 3. 자정 넘어가는 경우 (밤)
             ")"
     )
     Optional<LocalDate> findLastConflictingDate(

--- a/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
@@ -80,7 +80,10 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
     List<Booking> findAllByStatusAndCreatedAtBefore(BookingStatus status, LocalDateTime threshold);
 
 
-    // 특정 식당의 특정 시간대와 겹치는 가장 늦은 예약 날짜 찾기
+    /**
+     * 특정 식당의 브레이크 타임과 겹치는 가장 늦은 예약 날짜를 조회합니다.
+     * @param adjustedBreakStart 브레이크 시작 시간에서 식당의 예약 간격(bookingIntervalMinutes)을 뺀 시간
+     */
     @Query("select max(b.bookingDate) from Booking b " +
             "where b.store.id = :storeId " +
             "and b.status IN (com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.CONFIRMED, com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.PENDING) " +

--- a/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
@@ -78,4 +78,18 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
      * @return 만료된 예약 리스트
      */
     List<Booking> findAllByStatusAndCreatedAtBefore(BookingStatus status, LocalDateTime threshold);
+
+
+    // 특정 식당의 특정 시간대와 겹치는 가장 늦은 예약 날짜 찾기
+    @Query("select max(b.bookingDate) from Booking b " +
+            "where b.store.id = :storeId " +
+            "and b.status IN (com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.CONFIRMED, com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.PENDING) " +
+            "and b.bookingDate >= CURRENT_DATE " +
+            "and b.bookingTime >= :breakStart and b.bookingTime < :breakEnd"
+    )
+    Optional<LocalDate> findLastConflictingDate(
+            @Param("storeId") Long storeId,
+            @Param("breakStart") LocalTime breakStart,
+            @Param("breakEnd") LocalTime breakEnd
+    );
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
@@ -85,11 +85,16 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
             "where b.store.id = :storeId " +
             "and b.status IN (com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.CONFIRMED, com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.PENDING) " +
             "and b.bookingDate >= CURRENT_DATE " +
-            "and b.bookingTime >= :breakStart and b.bookingTime < :breakEnd"
+            "and (" +
+            "   (b.bookingTime >= :breakStart and b.bookingTime < :breakEnd) " + // 케이스 A: 브레이크 중에 예약 시작
+            "   OR " +
+            "   (b.bookingTime >= :adjustedBreakStart and b.bookingTime < :breakStart)" + // 케이스 B: 브레이크 전에 시작해서 걸침
+            ")"
     )
     Optional<LocalDate> findLastConflictingDate(
             @Param("storeId") Long storeId,
             @Param("breakStart") LocalTime breakStart,
-            @Param("breakEnd") LocalTime breakEnd
+            @Param("breakEnd") LocalTime breakEnd,
+            @Param("adjustedBreakStart") LocalTime adjustedBreakStart
     );
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/controller/BusinessHoursController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/controller/BusinessHoursController.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import java.time.LocalDate;
 
 @Tag(name = "BusinessHours", description = "영업시간 관련 API")
 @RequestMapping("/api/v1")
@@ -51,6 +52,14 @@ public class BusinessHoursController {
             @RequestBody BusinessHoursReqDto.UpdateBreakTimeDto dto,
             @CurrentUser User user
     ){
+        BusinessHoursResDto.UpdateBreakTimeDto result = businessHoursCommandService.updateBreakTime(storeId, dto, user.getUsername());
+
+        // 1. 날짜가 미래라면 DELAYED(지연) 코드 반환
+        if (result.effectiveDate().isAfter(LocalDate.now())) {
+            return ApiResponse.of(
+                    BusinessHoursSuccessStatus._UPDATE_BREAKTIME_DELAYED,
+                    result);
+        }
         return ApiResponse.of(
                 BusinessHoursSuccessStatus._UPDATE_BREAKTIME_SUCCESS,
                 businessHoursCommandService.updateBreakTime(storeId, dto, user.getUsername())

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/converter/BusinessHoursConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/converter/BusinessHoursConverter.java
@@ -4,6 +4,7 @@ import com.eatsfine.eatsfine.domain.businesshours.dto.BusinessHoursReqDto;
 import com.eatsfine.eatsfine.domain.businesshours.dto.BusinessHoursResDto;
 import com.eatsfine.eatsfine.domain.businesshours.entity.BusinessHours;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class BusinessHoursConverter {
@@ -49,11 +50,12 @@ public class BusinessHoursConverter {
                 .build();
     }
 
-    public static BusinessHoursResDto.UpdateBreakTimeDto toUpdateBreakTimeDto(Long storeId, BusinessHoursReqDto.UpdateBreakTimeDto dto) {
+    public static BusinessHoursResDto.UpdateBreakTimeDto toUpdateBreakTimeDto(Long storeId, BusinessHoursReqDto.UpdateBreakTimeDto dto, LocalDate effectiveDate) {
         return BusinessHoursResDto.UpdateBreakTimeDto.builder()
                 .storeId(storeId)
                 .breakStartTime(dto.breakStartTime())
                 .breakEndTime(dto.breakEndTime())
+                .effectiveDate(effectiveDate)
                 .build();
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/dto/BusinessHoursReqDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/dto/BusinessHoursReqDto.java
@@ -1,6 +1,7 @@
 package com.eatsfine.eatsfine.domain.businesshours.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -15,14 +16,18 @@ public class BusinessHoursReqDto {
     public record Summary(
 
             @NotNull(message = "요일은 필수입니다.")
+            @Schema(description = "요일", example = "MONDAY")
             DayOfWeek day,
 
+            @Schema(description = "영업 시작 시간", type = "string", example = "09:00")
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
             LocalTime openTime,
 
+            @Schema(description = "영업 종료 시간", type = "string", example = "22:00")
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
             LocalTime closeTime,
 
+            @Schema(description = "휴무 여부", example = "false")
             boolean isClosed
     ){}
 
@@ -36,10 +41,12 @@ public class BusinessHoursReqDto {
     public record UpdateBreakTimeDto(
 
             @NotNull(message = "브레이크타임 시작 시간은 필수입니다.")
+            @Schema(description = "브레이크 시작 시간", type = "string", example = "15:00")
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
             LocalTime breakStartTime,
 
             @NotNull(message = "브레이크타임 종료 시간은 필수입니다.")
+            @Schema(description = "브레이크 시작 시간", type = "string", example = "17:00")
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
             LocalTime breakEndTime
     ){}

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/dto/BusinessHoursReqDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/dto/BusinessHoursReqDto.java
@@ -46,7 +46,7 @@ public class BusinessHoursReqDto {
             LocalTime breakStartTime,
 
             @NotNull(message = "브레이크타임 종료 시간은 필수입니다.")
-            @Schema(description = "브레이크 시작 시간", type = "string", example = "17:00")
+            @Schema(description = "브레이크 종료 시간", type = "string", example = "17:00")
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
             LocalTime breakEndTime
     ){}

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/dto/BusinessHoursResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/dto/BusinessHoursResDto.java
@@ -1,9 +1,11 @@
 package com.eatsfine.eatsfine.domain.businesshours.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -38,6 +40,9 @@ public class BusinessHoursResDto {
             LocalTime breakStartTime,
 
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
-            LocalTime breakEndTime
+            LocalTime breakEndTime,
+
+            @JsonIgnore
+            LocalDate effectiveDate
     ){}
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/entity/BusinessHours.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/entity/BusinessHours.java
@@ -96,4 +96,10 @@ public class BusinessHours extends BaseEntity {
             this.effectiveDate = null;
         }
     }
+
+    public void clearPendingBreakTime() {
+        this.newBreakStartTime = null;
+        this.newBreakEndTime = null;
+        this.effectiveDate = null;
+    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/entity/BusinessHours.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/entity/BusinessHours.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Entity
@@ -39,25 +40,60 @@ public class BusinessHours extends BaseEntity {
     @Column(name = "break_end_time")
     private LocalTime breakEndTime;
 
+    @Column(name = "new_break_start_time")
+    private LocalTime newBreakStartTime;
+
+    @Column(name = "new_break_end_time")
+    private LocalTime newBreakEndTime;
+
+    @Column(name = "effective_date")
+    private LocalDate effectiveDate;
+
     // 휴일 여부 (특정 요일 고정 휴무)
     @Builder.Default
     @Column(name = "is_closed", nullable = false)
     private boolean isClosed = false;
 
-    public void assignStore(Store store){
+    public void assignStore(Store store) {
         this.store = store;
     }
 
     // 영업시간 변경
-    public void update(LocalTime open, LocalTime close, boolean isClosed){
+    public void update(LocalTime open, LocalTime close, boolean isClosed) {
         this.openTime = open;
         this.closeTime = close;
         this.isClosed = isClosed;
     }
 
     // 브레이크타임 변경
-    public void updateBreakTime(LocalTime breakStart, LocalTime breakEnd){
-        this.breakStartTime = breakStart;
-        this.breakEndTime = breakEnd;
+    public void updateBreakTime(LocalTime startTime, LocalTime endTime, LocalDate effectiveDate) {
+        // 오늘(혹은 과거) 날짜라면 -> 즉시 반영
+        if (effectiveDate == null || !effectiveDate.isAfter(LocalDate.now())) {
+            this.breakStartTime = startTime;
+            this.breakEndTime = endTime;
+            // 대기 중인 데이터 초기화
+            this.newBreakStartTime = null;
+            this.newBreakEndTime = null;
+            this.effectiveDate = null;
+        }
+        // 미래 날짜라면 -> 대기열에 저장
+        else {
+            this.newBreakStartTime = startTime;
+            this.newBreakEndTime = endTime;
+            this.effectiveDate = effectiveDate;
+        }
+    }
+
+    // 대기열 -> 실제 반영 (스케줄러 호출)
+    public void applyPendingBreakTime() {
+        if (this.newBreakStartTime != null && this.newBreakEndTime != null) {
+            this.breakStartTime = newBreakStartTime;
+            this.breakEndTime = newBreakEndTime;
+
+            // 반영 후 대기열 비우기
+            this.newBreakStartTime = null;
+            this.newBreakEndTime = null;
+            this.effectiveDate = null;
+        }
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/repository/BusinessHoursRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/repository/BusinessHoursRepository.java
@@ -11,5 +11,5 @@ import java.util.Optional;
 
 public interface BusinessHoursRepository extends JpaRepository<BusinessHours, Long> {
     Optional<BusinessHours> findByStoreAndDayOfWeek(Store store, DayOfWeek dayOfWeek);
-    List<BusinessHours> findAllByEffectiveDate(LocalDate date);
+    List<BusinessHours> findAllByEffectiveDateLessThanEqualAndEffectiveDateIsNotNull(LocalDate date);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/repository/BusinessHoursRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/repository/BusinessHoursRepository.java
@@ -5,8 +5,11 @@ import com.eatsfine.eatsfine.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface BusinessHoursRepository extends JpaRepository<BusinessHours, Long> {
     Optional<BusinessHours> findByStoreAndDayOfWeek(Store store, DayOfWeek dayOfWeek);
+    List<BusinessHours> findAllByEffectiveDate(LocalDate date);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/service/BusinessHoursCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/service/BusinessHoursCommandServiceImpl.java
@@ -6,6 +6,7 @@ import com.eatsfine.eatsfine.domain.businesshours.dto.BusinessHoursReqDto;
 import com.eatsfine.eatsfine.domain.businesshours.dto.BusinessHoursResDto;
 import com.eatsfine.eatsfine.domain.businesshours.entity.BusinessHours;
 import com.eatsfine.eatsfine.domain.businesshours.exception.BusinessHoursException;
+import com.eatsfine.eatsfine.domain.businesshours.status.BusinessHoursErrorStatus;
 import com.eatsfine.eatsfine.domain.businesshours.validator.BreakTimeValidator;
 import com.eatsfine.eatsfine.domain.businesshours.validator.BusinessHoursValidator;
 import com.eatsfine.eatsfine.domain.store.entity.Store;
@@ -88,6 +89,11 @@ public class BusinessHoursCommandServiceImpl implements BusinessHoursCommandServ
             }
             return BusinessHoursConverter.toUpdateBreakTimeDto(storeId, dto, null);
 
+        }
+
+        // 한쪽만 null인 비정상 요청 방어
+        if (dto.breakStartTime() == null || dto.breakEndTime() == null) {
+            throw new BusinessHoursException(BusinessHoursErrorStatus._INVALID_BREAK_TIME);
         }
 
         LocalTime adjustedBreakStart = dto.breakStartTime().minusMinutes(store.getBookingIntervalMinutes());

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/service/BusinessHoursScheduler.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/service/BusinessHoursScheduler.java
@@ -1,0 +1,36 @@
+package com.eatsfine.eatsfine.domain.businesshours.service;
+
+import com.eatsfine.eatsfine.domain.businesshours.entity.BusinessHours;
+import com.eatsfine.eatsfine.domain.businesshours.repository.BusinessHoursRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BusinessHoursScheduler {
+
+    private final BusinessHoursRepository businessHoursRepository;
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정
+    @Transactional
+    public void applyPendingBreakTimes() {
+        log.info("[Scheduler] 브레이크 타임 지연 반영 작업 시작");
+
+        List<BusinessHours> targets = businessHoursRepository.findAllByEffectiveDate(LocalDate.now());
+
+        if(targets.isEmpty()) {
+            log.info("[Scheduler] 오늘 반영할 항목이 없습니다.");
+            return;
+        }
+
+        targets.forEach(BusinessHours::applyPendingBreakTime);
+        log.info("[Scheduler] 총 {}건의 브레이크 타임이 성공적으로 갱신되었습니다.", targets.size());
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/service/BusinessHoursScheduler.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/service/BusinessHoursScheduler.java
@@ -1,12 +1,15 @@
 package com.eatsfine.eatsfine.domain.businesshours.service;
 
 import com.eatsfine.eatsfine.domain.businesshours.entity.BusinessHours;
+import com.eatsfine.eatsfine.domain.businesshours.exception.BusinessHoursException;
 import com.eatsfine.eatsfine.domain.businesshours.repository.BusinessHoursRepository;
+import com.eatsfine.eatsfine.domain.businesshours.status.BusinessHoursErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,6 +20,7 @@ import java.util.List;
 public class BusinessHoursScheduler {
 
     private final BusinessHoursRepository businessHoursRepository;
+    private final TransactionTemplate transactionTemplate;
 
     @Scheduled(cron = "0 0 0 * * *")
     public void applyPendingBreakTimes() {
@@ -24,31 +28,41 @@ public class BusinessHoursScheduler {
 
         List<BusinessHours> pendingList = businessHoursRepository.findAllByEffectiveDateLessThanEqualAndEffectiveDateIsNotNull(LocalDate.now());
 
+        int successCount = 0;
+        int failCount = 0;
+        int warnCount = 0; // 데이터 불일치(XOR) 건수
+
         // 전체 대상 건수 로그
         log.info("[Scheduler] 처리 대상 건수: {}건", pendingList.size());
 
-        int successCount = 0;
-
         for (BusinessHours bh : pendingList) {
             try {
-                processEachPendingTime(bh);
-                successCount++;
-
+                Boolean isApplied = transactionTemplate.execute(status -> processEachPendingTime(bh.getId()));
+                if(Boolean.TRUE.equals(isApplied)) {
+                    successCount++;
+                } else {
+                    warnCount++; // XOR 등으로 인해 초기화만 된 경우
+                }
             } catch (Exception e) {
+                failCount++;
                 // 개별 건 처리 중 에러 발생 시 로그 남기고 다음 건 진행
-                log.error("[Scheduler Exception] 반영 실패 - BH ID: {}, Error: {}", bh.getId(), e.getMessage());
+                log.error("[Scheduler Exception] 반영 실패 - BH ID: {}", bh.getId(), e);
             }
         }
         log.info("[Scheduler] 반영 작업 완료. (성공: {}/{} 건)", successCount, pendingList.size());
     }
 
-    @Transactional
-    public void processEachPendingTime(BusinessHours bh) {
+    public boolean processEachPendingTime(Long bhId) {
+
+        BusinessHours bh = businessHoursRepository.findById(bhId)
+                .orElseThrow(() -> new BusinessHoursException(BusinessHoursErrorStatus._BUSINESS_HOURS_NOT_FOUND));
+
         if((bh.getNewBreakStartTime() == null) ^ (bh.getNewBreakEndTime() == null)) {
             log.warn("[XOR Error] ID: {}", bh.getId());
             bh.clearPendingBreakTime();
-            return;
+            return false; // 초기화만 한 경우 false 리턴
         }
         bh.applyPendingBreakTime();
+        return true; // 정상 반영한 경우 true 리턴
     }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/status/BusinessHoursErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/status/BusinessHoursErrorStatus.java
@@ -17,7 +17,7 @@ public enum BusinessHoursErrorStatus implements BaseErrorCode {
     _INVALID_CLOSED_DAY(HttpStatus.BAD_REQUEST, "BUSINESS_HOURS4005", "휴무일에는 영업시간이 존재할 수 없습니다."),
     _BUSINESS_HOURS_DAY_NOT_FOUND(HttpStatus.NOT_FOUND, "BUSINESS_HOURS404", "해당 요일에 대한 영업시간 정보가 존재하지 않습니다."),
     _INVALID_BREAK_TIME(HttpStatus.BAD_REQUEST, "BUSINESS_HOURS4006", "브레이크타임 시작 시간은 종료 시간보다 빨라야 합니다.(심야 영업 시간 고려 필수)"),
-    _BREAK_TIME_OUT_OF_BUSINESS_HOURS(HttpStatus.BAD_REQUEST, "BUSINESS_HOURS4007", "브레이크타임은 영업시간 내에만 설정할 수 있습니다."),
+    _BREAK_TIME_NOT_ALLOWED_FOR_24H(HttpStatus.BAD_REQUEST, "BUSINESS_HOURS4005", "24시간 영업 매장은 브레이크 타임을 설정할 수 없습니다."),
     ;
 
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/status/BusinessHoursErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/status/BusinessHoursErrorStatus.java
@@ -16,7 +16,7 @@ public enum BusinessHoursErrorStatus implements BaseErrorCode {
     _INVALID_OPEN_DAY(HttpStatus.BAD_REQUEST, "BUSINESS_HOURS4004", "영업일에는 영업시간 및 마감 시간이 존재해야 합니다."),
     _INVALID_CLOSED_DAY(HttpStatus.BAD_REQUEST, "BUSINESS_HOURS4005", "휴무일에는 영업시간이 존재할 수 없습니다."),
     _BUSINESS_HOURS_DAY_NOT_FOUND(HttpStatus.NOT_FOUND, "BUSINESS_HOURS404", "해당 요일에 대한 영업시간 정보가 존재하지 않습니다."),
-    _INVALID_BREAK_TIME(HttpStatus.BAD_REQUEST, "BUSINESS_HOURS4006", "브레이크타임 시작 시간은 종료 시간보다 빨라야 합니다."),
+    _INVALID_BREAK_TIME(HttpStatus.BAD_REQUEST, "BUSINESS_HOURS4006", "브레이크타임 시작 시간은 종료 시간보다 빨라야 합니다.(심야 영업 시간 고려 필수)"),
     _BREAK_TIME_OUT_OF_BUSINESS_HOURS(HttpStatus.BAD_REQUEST, "BUSINESS_HOURS4007", "브레이크타임은 영업시간 내에만 설정할 수 있습니다."),
     ;
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/status/BusinessHoursErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/status/BusinessHoursErrorStatus.java
@@ -17,7 +17,8 @@ public enum BusinessHoursErrorStatus implements BaseErrorCode {
     _INVALID_CLOSED_DAY(HttpStatus.BAD_REQUEST, "BUSINESS_HOURS4005", "휴무일에는 영업시간이 존재할 수 없습니다."),
     _BUSINESS_HOURS_DAY_NOT_FOUND(HttpStatus.NOT_FOUND, "BUSINESS_HOURS404", "해당 요일에 대한 영업시간 정보가 존재하지 않습니다."),
     _INVALID_BREAK_TIME(HttpStatus.BAD_REQUEST, "BUSINESS_HOURS4006", "브레이크타임 시작 시간은 종료 시간보다 빨라야 합니다.(심야 영업 시간 고려 필수)"),
-    _BREAK_TIME_NOT_ALLOWED_FOR_24H(HttpStatus.BAD_REQUEST, "BUSINESS_HOURS4005", "24시간 영업 매장은 브레이크 타임을 설정할 수 없습니다."),
+    _BREAK_TIME_NOT_ALLOWED_FOR_24H(HttpStatus.BAD_REQUEST, "BUSINESS_HOURS4007", "24시간 영업 매장은 브레이크 타임을 설정할 수 없습니다."),
+    _BUSINESS_HOURS_NOT_FOUND(HttpStatus.NOT_FOUND, "BUSINESS_HOURS4008", "영업시간 정보가 존재하지 않습니다."),
     ;
 
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/status/BusinessHoursSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/status/BusinessHoursSuccessStatus.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum BusinessHoursSuccessStatus implements BaseCode {
 
     _UPDATE_BUSINESS_HOURS_SUCCESS(HttpStatus.OK, "BUSINESS_HOURS200", "영업시간이 성공적으로 수정되었습니다."),
-    _UPDATE_BREAKTIME_SUCCESS(HttpStatus.OK, "BUSINESS_HOURS2001", "브레이크타임이 성공적으로 설정되었습니다.")
+    _UPDATE_BREAKTIME_SUCCESS(HttpStatus.OK, "BUSINESS_HOURS2001", "브레이크타임이 성공적으로 설정되었습니다."),
+    _UPDATE_BREAKTIME_DELAYED(HttpStatus.OK, "BUSINESS_HOURS2002", "기존 예약이 존재하여, 마지막 예약 종료 후 다음 날부터 반영됩니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/validator/BreakTimeValidator.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/validator/BreakTimeValidator.java
@@ -17,7 +17,7 @@ public class BreakTimeValidator {
         // 24시간 영업이면 모든 브레이크 타임 X
         if (openTime.equals(closeTime)) {
             throw new BusinessHoursException(BusinessHoursErrorStatus._BREAK_TIME_NOT_ALLOWED_FOR_24H);
-        };
+        }
 
         // 1. 브레이크 시작 < 종료 검증 (자정을 넘기는 브레이크 타임은 없다고 가정)
         if (!breakEndTime.isAfter(breakStartTime)) {

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/validator/BreakTimeValidator.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/validator/BreakTimeValidator.java
@@ -10,20 +10,34 @@ public class BreakTimeValidator {
     public static void validateBreakTime(LocalTime openTime, LocalTime closeTime, LocalTime breakStartTime, LocalTime breakEndTime) {
 
         // 휴무일은 검증 대상이 아님
-        if(openTime == null || closeTime == null) {
+        if (openTime == null || closeTime == null || breakStartTime == null || breakEndTime == null) {
             return;
         }
 
-        // start < end
-        if(!breakEndTime.isAfter(breakStartTime)) {
+        // 24시간 영업이면 모든 브레이크 타임 X
+        if (openTime.equals(closeTime)) return;
+
+        // 1. 브레이크 시작 < 종료 검증 (자정을 넘기는 브레이크 타임은 없다고 가정)
+        if (!breakEndTime.isAfter(breakStartTime)) {
             throw new BusinessHoursException(BusinessHoursErrorStatus._INVALID_BREAK_TIME);
         }
 
-        // 브레이크타임이 영업시간 내에 존재
-        if(breakStartTime.isBefore(openTime) || breakEndTime.isAfter(closeTime)) {
-            throw new BusinessHoursException(BusinessHoursErrorStatus._BREAK_TIME_OUT_OF_BUSINESS_HOURS);
+        // 2. 브레이크 타임이 영업시간 내에 있는지 검증
+        if (openTime.isBefore(closeTime)) {
+            // 일반 영업: open <= breakStartTime AND breakEndTime <= close 여야 함
+            if (breakStartTime.isBefore(openTime) || breakEndTime.isAfter(closeTime)) {
+                throw new BusinessHoursException(BusinessHoursErrorStatus._INVALID_BREAK_TIME);
+            }
+        } else {
+            // 심야 영업: [close ~ open] 사이(영업 안 하는 시간)에 브레이크 타임이 있으면 에러
+            if (!breakStartTime.isBefore(closeTime) && breakStartTime.isBefore(openTime)) {
+                throw new BusinessHoursException(BusinessHoursErrorStatus._INVALID_BREAK_TIME);
+            }
+            if (!breakEndTime.isBefore(closeTime) && breakEndTime.isBefore(openTime)) {
+                throw new BusinessHoursException(BusinessHoursErrorStatus._INVALID_BREAK_TIME);
+            }
         }
-
 
     }
 }
+

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/validator/BreakTimeValidator.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/validator/BreakTimeValidator.java
@@ -15,7 +15,9 @@ public class BreakTimeValidator {
         }
 
         // 24시간 영업이면 모든 브레이크 타임 X
-        if (openTime.equals(closeTime)) return;
+        if (openTime.equals(closeTime)) {
+            throw new BusinessHoursException(BusinessHoursErrorStatus._BREAK_TIME_NOT_ALLOWED_FOR_24H);
+        };
 
         // 1. 브레이크 시작 < 종료 검증 (자정을 넘기는 브레이크 타임은 없다고 가정)
         if (!breakEndTime.isAfter(breakStartTime)) {

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/validator/BusinessHoursValidator.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/validator/BusinessHoursValidator.java
@@ -16,14 +16,14 @@ public class BusinessHoursValidator {
         validateDuplicateDayOfWeek(dto);
         validateOpenDay(dto);
         validateClosedDay(dto);
-        //validateOpenCloseTime(dto);
+        validateOpenCloseTime(dto);
     }
 
     public static void validateForUpdate(List<BusinessHoursReqDto.Summary> dto) {
         validateDuplicateDayOfWeek(dto);
         validateOpenDay(dto);
         validateClosedDay(dto);
-        //validateOpenCloseTime(dto);
+        validateOpenCloseTime(dto);
     }
 
     // 7일 모두 입력 여부 검증
@@ -37,8 +37,9 @@ public class BusinessHoursValidator {
     private static void validateOpenCloseTime(List<BusinessHoursReqDto.Summary> dto) {
         for(BusinessHoursReqDto.Summary s: dto) {
             if(!s.isClosed()){
-                if(s.openTime().isAfter(s.closeTime())) {
-                    throw new BusinessHoursException(BusinessHoursErrorStatus._INVALID_BUSINESS_TIME);
+                // 24시간 영업 허용
+                if(s.openTime().equals(s.closeTime())) {
+                    continue;
                 }
             }
         }

--- a/src/main/java/com/eatsfine/eatsfine/domain/businesshours/validator/BusinessHoursValidator.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/businesshours/validator/BusinessHoursValidator.java
@@ -16,14 +16,14 @@ public class BusinessHoursValidator {
         validateDuplicateDayOfWeek(dto);
         validateOpenDay(dto);
         validateClosedDay(dto);
-        validateOpenCloseTime(dto);
+        //validateOpenCloseTime(dto);
     }
 
     public static void validateForUpdate(List<BusinessHoursReqDto.Summary> dto) {
         validateDuplicateDayOfWeek(dto);
         validateOpenDay(dto);
         validateClosedDay(dto);
-        validateOpenCloseTime(dto);
+        //validateOpenCloseTime(dto);
     }
 
     // 7일 모두 입력 여부 검증

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryServiceImpl.java
@@ -119,8 +119,8 @@ public class StoreQueryServiceImpl implements StoreQueryService {
 
         // 1. 영업 시간 범위 먼저 체크
         if (open.equals(close)) {
+            isWithinBusinessHours = isToday;
             // 24시간 영업
-            isWithinBusinessHours = true;
         } else if (open.isBefore(close)) {
             // 일반 영업 (예: 09:00 ~ 18:00)
             isWithinBusinessHours = isToday && (!time.isBefore(open) && time.isBefore(close));


### PR DESCRIPTION
### 💡 작업 개요
- 익일 영업시간을 넘어가는 심야 영업시간(예: 18:00~02:00)도 허용되도록 수정
- 브레이크 타임 검증 로직도 심야 영업시간을 고려하도록 수정
- 새로운 브레이크 타임 설정 시 예약과 브레이크 타임 충돌 검증(마지막 예약 다음 날부터 적용되도록 수정)
- 해당 날짜 자정이 되면 스케쥴러가 브레이크 타임 자동 반영

### ✅ 작업 내용
- [x] 기능 개발
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

### 🧪 테스트 내용
- 가게 등록 시 심야 영업시간 설정
<img width="814" height="691" alt="image" src="https://github.com/user-attachments/assets/dd49e687-38fa-4f80-a94e-c3bbdf7c7cc6" />
- 상세 조회 시 정상 반영
<img width="818" height="521" alt="image" src="https://github.com/user-attachments/assets/04c0bd50-277d-4b26-ae27-7f8862df120f" />

- 브레이크 타임과 예약(PENDING, CONFIRMED)가 겹칠 시, 마지막 예약 다음 날부터 적용되도록 방어 로직 구현 
<img width="822" height="292" alt="image" src="https://github.com/user-attachments/assets/97d3f5c0-0aa2-4e80-8ed8-eb104be215d4" />



### 📝 기타 참고 사항
- 브레이크 타임은 가게 공통 사항이므로, 일반 영업시간과 심야 영업시간 공통의 영업시간 사이에 위치해야 하는 점 주의 요망

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 주요 변경사항

* **New Features**
  * 브레이크 타임의 미래 적용(유예) 지원 및 유예된 변경을 자정에 일괄 적용하는 스케줄러 추가
  * 브레이크 타임 삭제 요청 처리 및 적용일(effective date)을 응답에 포함해 지연 적용 여부 반환

* **Bug Fixes**
  * 심야(오버나이트)·24시간 영업을 고려한 영업/브레이크 판단 및 검증 로직 강화
  * 브레이크 타임 검증 오류 메시지·상태 개선

* **Documentation**
  * API 응답 필드에 한글 설명 및 예시 추가 (스키마 주석 보강)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->