### PR TITLE
[FEAT]: 마이페이지에서의 내 가게 리스트 조회 API 추가

### DIFF
--- a/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
@@ -121,4 +121,12 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
             "com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.PENDING, " +
             "com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.COMPLETED)")
     Long countActiveBookings(@Param("store") Store store);
+
+    @Query("select b.store.id, count(b) from Booking b " +
+            "where b.store in :stores " +
+            "and b.status in (com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.CONFIRMED, " +
+            "com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.PENDING, " +
+            "com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.COMPLETED) " +
+            "group by b.store.id")
+    List<Object[]> countActiveBookingsByStores(@Param("stores") List<Store> stores);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/booking/repository/BookingRepository.java
@@ -2,6 +2,7 @@ package com.eatsfine.eatsfine.domain.booking.repository;
 
 import com.eatsfine.eatsfine.domain.booking.entity.Booking;
 import com.eatsfine.eatsfine.domain.booking.enums.BookingStatus;
+import com.eatsfine.eatsfine.domain.store.entity.Store;
 import com.eatsfine.eatsfine.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -114,4 +115,10 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
             @Param("currentDate") LocalDate currentDate,
             @Param("currentTime") LocalTime currentTime
     );
+    @Query("select count(b) from Booking b " +
+            "where b.store = :store " +
+            "and b.status in (com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.CONFIRMED, " +
+            "com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.PENDING, " +
+            "com.eatsfine.eatsfine.domain.booking.enums.BookingStatus.COMPLETED)")
+    Long countActiveBookings(@Param("store") Store store);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/controller/StoreController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/controller/StoreController.java
@@ -117,7 +117,7 @@ public class StoreController {
     public ApiResponse<StoreResDto.MyStoreListDto> getMyStores(
             @CurrentUser User user
     ) {
-        return ApiResponse.of(StoreSuccessStatus._STORE_FOUND, storeQueryService.getMyStores(user.getUsername()));
+        return ApiResponse.of(StoreSuccessStatus._MY_STORE_LIST_FOUND, storeQueryService.getMyStores(user.getUsername()));
     }
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/controller/StoreController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/controller/StoreController.java
@@ -108,4 +108,16 @@ public class StoreController {
         return ApiResponse.of(StoreSuccessStatus._STORE_MAIN_IMAGE_GET_SUCCESS, storeQueryService.getMainImage(storeId));
     }
 
+    @Operation(
+            summary = "내 가게 리스트 조회",
+            description = "사장님이 등록한 모든 가게 리스트를 조회합니다."
+    )
+    @GetMapping("/stores/my")
+    @PreAuthorize("hasRole('OWNER')")
+    public ApiResponse<StoreResDto.MyStoreListDto> getMyStores(
+            @CurrentUser User user
+    ) {
+        return ApiResponse.of(StoreSuccessStatus._STORE_FOUND, storeQueryService.getMyStores(user.getUsername()));
+    }
+
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/converter/StoreConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/converter/StoreConverter.java
@@ -79,5 +79,24 @@ public class StoreConverter {
                 .mainImageUrl(key)
                 .build();
     }
-}
 
+    public static StoreResDto.MyStoreDto toMyStoreDto(Store store, boolean isOpenNow, Long totalBookingCount, String mainImageUrl) {
+        return StoreResDto.MyStoreDto.builder()
+                .storeId(store.getId())
+                .storeName(store.getStoreName())
+                .address(store.getAddress())
+                .category(store.getCategory())
+                .rating(store.getRating())
+                .totalBookingCount(totalBookingCount)
+                .reviewCount(null) // 리뷰 도메인 구현 이후 추가 예정
+                .mainImageUrl(mainImageUrl)
+                .isOpenNow(isOpenNow)
+                .build();
+    }
+
+    public static StoreResDto.MyStoreListDto toMyStoreListDto(List<StoreResDto.MyStoreDto> stores) {
+        return StoreResDto.MyStoreListDto.builder()
+                .stores(stores)
+                .build();
+    }
+}

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/converter/StoreConverter.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/converter/StoreConverter.java
@@ -80,7 +80,7 @@ public class StoreConverter {
                 .build();
     }
 
-    public static StoreResDto.MyStoreDto toMyStoreDto(Store store, boolean isOpenNow, Long totalBookingCount, String mainImageUrl) {
+    public static StoreResDto.MyStoreDto toMyStoreDto(Store store, boolean isOpenNow, String mainImageUrl, Long totalBookingCount) {
         return StoreResDto.MyStoreDto.builder()
                 .storeId(store.getId())
                 .storeName(store.getStoreName())

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/dto/StoreResDto.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/dto/StoreResDto.java
@@ -4,6 +4,7 @@ import com.eatsfine.eatsfine.domain.businesshours.dto.BusinessHoursResDto;
 import com.eatsfine.eatsfine.domain.store.enums.Category;
 import com.eatsfine.eatsfine.domain.store.enums.DepositRate;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.math.BigDecimal;
@@ -90,5 +91,36 @@ public class StoreResDto {
             Long storeId,
             String mainImageUrl
     ) {}
+
+    // 내 가게 관리 리스트 응답
+    @Builder
+    @Schema(description = "사장님용 내 가게 관리 단건 DTO")
+    public record MyStoreDto(
+            @Schema(description = "가게 ID", example = "1")
+            Long storeId,
+            @Schema(description = "가게명", example = "더 플레이스 강남점")
+            String storeName,
+            @Schema(description = "가게 주소", example = "서울 강남구 테헤란로 123")
+            String address,
+            @Schema(description = "카테고리", example = "ITALIAN")
+            Category category,
+            @Schema(description = "평점", example = "4.8")
+            BigDecimal rating,
+            @Schema(description = "누적 총 예약 수", example = "1234")
+            Long totalBookingCount, // 총 예약 수
+            @Schema(description = "리뷰 개수", example = "256")
+            Long reviewCount,
+            @Schema(description = "대표 이미지 URL", example = "https://s3.amazonaws.com/thumb.jpg")
+            String mainImageUrl,
+            @Schema(description = "현재 영업 여부", example = "true")
+            boolean isOpenNow
+    ){}
+
+    @Builder
+    @Schema(description = "사장님용 내 가게 관리 목록 응답")
+    public record MyStoreListDto(
+            @Schema(description = "소유한 가게 목록")
+            List<MyStoreDto> stores
+    ){}
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/enums/Category.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/enums/Category.java
@@ -1,5 +1,5 @@
 package com.eatsfine.eatsfine.domain.store.enums;
 
 public enum Category {
-    KOREAN, CHINESE, JAPANESE, WESTERN, CAFE
+    KOREAN, CHINESE, JAPANESE, WESTERN, ITALIAN, CAFE
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/repository/StoreRepository.java
@@ -1,10 +1,12 @@
 package com.eatsfine.eatsfine.domain.store.repository;
 
 import com.eatsfine.eatsfine.domain.store.entity.Store;
+import com.eatsfine.eatsfine.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -18,5 +20,7 @@ public interface StoreRepository extends JpaRepository<Store, Long>, StoreReposi
 
 """)
     Optional<Store> findByIdWithMenus(@Param("id") Long id);
+
+    List<Store> findAllByOwner(User owner);
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/repository/StoreRepository.java
@@ -21,6 +21,7 @@ public interface StoreRepository extends JpaRepository<Store, Long>, StoreReposi
 """)
     Optional<Store> findByIdWithMenus(@Param("id") Long id);
 
+    @Query("select s from Store s left join fetch s.businessHours where s.owner = :owner")
     List<Store> findAllByOwner(User owner);
 
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryService.java
@@ -21,4 +21,6 @@ public interface StoreQueryService {
 
     boolean isOpenNow(Store store, LocalDateTime now);
 
+    StoreResDto.MyStoreListDto getMyStores(String username);
+
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/service/StoreQueryServiceImpl.java
@@ -152,13 +152,17 @@ public class StoreQueryServiceImpl implements StoreQueryService {
         return false; // 영업 시간 자체가 아님
     }
 
+    // 내 가게 리스트 조회
     @Override
     public StoreResDto.MyStoreListDto getMyStores(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserException(UserErrorStatus.MEMBER_NOT_FOUND));
 
         List<Store> myStores = storeRepository.findAllByOwner(user);
-        
+
+        if(myStores.isEmpty()) {
+            return StoreConverter.toMyStoreListDto(List.of());
+        }
         // N+1 문제 해결을 위한 Bulk Query 실행
         List<Object[]> bookingCounts = bookingRepository.countActiveBookingsByStores(myStores);
         Map<Long, Long> bookingCountMap = bookingCounts.stream()

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreSuccessStatus.java
@@ -22,7 +22,9 @@ public enum StoreSuccessStatus implements BaseCode {
 
     _STORE_MAIN_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "STORE2005", "성공적으로 가게 대표 이미지를 업로드했습니다."),
 
-    _STORE_MAIN_IMAGE_GET_SUCCESS(HttpStatus.OK, "STORE2005", "성공적으로 가게 대표 이미지를 조회했습니다.")
+    _STORE_MAIN_IMAGE_GET_SUCCESS(HttpStatus.OK, "STORE2005", "성공적으로 가게 대표 이미지를 조회했습니다."),
+
+    _MY_STORE_LIST_FOUND(HttpStatus.OK, "STORE2006", "성공적으로 내 가게 리스트를 조회했습니다.")
     ;
 
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreSuccessStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/store/status/StoreSuccessStatus.java
@@ -22,9 +22,9 @@ public enum StoreSuccessStatus implements BaseCode {
 
     _STORE_MAIN_IMAGE_UPLOAD_SUCCESS(HttpStatus.OK, "STORE2005", "성공적으로 가게 대표 이미지를 업로드했습니다."),
 
-    _STORE_MAIN_IMAGE_GET_SUCCESS(HttpStatus.OK, "STORE2005", "성공적으로 가게 대표 이미지를 조회했습니다."),
+    _STORE_MAIN_IMAGE_GET_SUCCESS(HttpStatus.OK, "STORE2006", "성공적으로 가게 대표 이미지를 조회했습니다."),
 
-    _MY_STORE_LIST_FOUND(HttpStatus.OK, "STORE2006", "성공적으로 내 가게 리스트를 조회했습니다.")
+    _MY_STORE_LIST_FOUND(HttpStatus.OK, "STORE2007", "성공적으로 내 가게 리스트를 조회했습니다.")
     ;
 
 


### PR DESCRIPTION
### 💡 작업 개요
- 마이페이지에서의 내 가게 리스트 조회 API를 추가했습니다.

### ✅ 작업 내용
- [x] 기능 개발
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

### 🧪 테스트 내용
- 로컬 정상 빌드 확인
- Swagger에서 정상 작동 확인
<img width="815" height="539" alt="image" src="https://github.com/user-attachments/assets/9cb076a7-0a54-4fae-bebc-120a9f8d794d" />

### 📝 기타 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자가 소유한 매장 목록 조회 엔드포인트 추가 (GET /api/v1/stores/my)
  * 매장별 활성 예약 수 집계 제공으로 각 매장의 총 예약 수 확인 가능
  * 식당 카테고리에 이탈리안(Italian) 추가
* **문서화**
  * 소유 매장 응답 DTO 및 API 스키마 설명 추가
* **응답 코드**
  * 소유 매장 조회 성공용 성공 코드·메시지 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->