### PR TITLE
[FIX]: 배치도 재생성 시 Unique 제약 조건 오류 해결

### DIFF
--- a/src/main/java/com/eatsfine/eatsfine/domain/table_layout/service/TableLayoutCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/table_layout/service/TableLayoutCommandServiceImpl.java
@@ -48,8 +48,10 @@ public class TableLayoutCommandServiceImpl implements TableLayoutCommandService 
                 throw new TableLayoutException(TableLayoutErrorStatus._CANNOT_DELETE_LAYOUT_WITH_FUTURE_BOOKINGS);
             }
             
-            // 미래 예약이 없으면 배치도 비활성화 후 재생성
+            // 미래 예약이 없으면 배치도와 속해있는 테이블 삭제 (soft delete)
             tableLayoutRepository.delete(existingLayout.get());
+
+            tableLayoutRepository.flush();
         }
 
         // 새 배치도 생성


### PR DESCRIPTION
### 💡 작업 개요
이전에 한 가게에 `isActive = true`인 배치도가 1개 이상 존재하는 것을 방지하기 위해 Unique 제약 조건을 추가했습니다.
기존 배치도가 삭제되면 `isActive = false, store_active_key = null`로 변경되야 합니다.

배치도 삭제 - 재생성 로직이 하나의 트랜잭션에서 동작하여 JPA 영속성 컨텍스트에서는 아직 반영되지 않아
`store_active_key`는 null로 값이 바뀌지 않아 Unique 제약 위반을 하게 됩니다.

그래서 `tableLayoutRepository.delete()` 이후 `flush()`를 추가하여 DB에 즉시 반영되도록 코드를 수정했습니다.

### ✅ 작업 내용
- [ ] 기능 개발
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

### 🧪 테스트 내용
- Swagger 테스트 시 정상 작동, 기존 배치도는 `isActive = false, store_active_key = null`로 변경된 것을 확인.

### 📝 기타 참고 사항
- 협업 관련 이슈, 주의 사항 등
