### PR TITLE
[FEAT]: 테스트코드 추가 및 개선

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,48 @@
+# ============================================
+# Eatsfine Backend - 환경변수 설정 가이드
+# ============================================
+# 이 파일을 `.env`로 복사한 뒤, 실제 값을 입력하세요.
+# cp .env.example .env
+#
+# ⚠️ 주의: .env 파일은 절대 Git에 커밋하지 마세요!
+# ============================================
+
+# ── Database (MySQL) ──────────────────────────
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=eatsfine_local
+DB_USERNAME=root
+DB_PASSWORD=your_password
+
+# ── Redis ─────────────────────────────────────
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+# ── JWT ───────────────────────────────────────
+SECRET_KEY=your_jwt_secret_key_must_be_long_enough_32chars
+
+# ── Toss Payments ─────────────────────────────
+# 토스페이먼츠 개발자센터에서 테스트 시크릿 키 발급
+# https://developers.tosspayments.com
+TOSS_WIDGET_SECRET_KEY=test_sk_xxxxxxxxxxxxxxxx
+
+# ── OAuth2 (Google) ───────────────────────────
+# Google Cloud Console에서 OAuth 2.0 클라이언트 ID 발급
+# https://console.cloud.google.com/apis/credentials
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+
+# ── OAuth2 (Kakao) ────────────────────────────
+# 카카오 개발자센터에서 앱 키 발급
+# https://developers.kakao.com
+KAKAO_CLIENT_ID=your_kakao_client_id
+KAKAO_CLIENT_SECRET=your_kakao_client_secret
+
+# ── AWS S3 ────────────────────────────────────
+AWS_REGION=ap-northeast-2
+AWS_S3_BUCKET=your-bucket-name
+AWS_S3_BASE_URL=https://your-bucket-name.s3.ap-northeast-2.amazonaws.com
+
+# ── 사업자등록 조회 API ───────────────────────
+# 공공데이터포털에서 API 키 발급
+BIZ_API_KEY=your_biz_api_key

--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,10 @@ KAKAO_CLIENT_ID=your_kakao_client_id
 KAKAO_CLIENT_SECRET=your_kakao_client_secret
 
 # ── AWS S3 ────────────────────────────────────
+# AWS IAM에서 액세스 키 발급 (로컬 개발 시 필수)
+# https://console.aws.amazon.com/iam
+AWS_ACCESS_KEY_ID=your_aws_access_key_id
+AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
 AWS_REGION=ap-northeast-2
 AWS_S3_BUCKET=your-bucket-name
 AWS_S3_BASE_URL=https://your-bucket-name.s3.ap-northeast-2.amazonaws.com

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ out/
 .vscode/
 
 ### secret properties files ###
+.env
 /src/main/resources/application-blue.yml
 /src/main/resources/application-green.yml
 /src/main/resources/application-local.yml
@@ -53,3 +54,7 @@ build.gradle
 
 src/main/resources/static/payment-test.html
 src/main/resources/static/payment-success.html
+
+
+.agent/rules
+.agent/skills

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/controller/PaymentController.java
@@ -1,18 +1,17 @@
 package com.eatsfine.eatsfine.domain.payment.controller;
+
 import com.eatsfine.eatsfine.domain.payment.dto.request.PaymentConfirmDTO;
 import com.eatsfine.eatsfine.domain.payment.dto.request.PaymentRequestDTO;
 import com.eatsfine.eatsfine.domain.payment.dto.response.PaymentResponseDTO;
 import com.eatsfine.eatsfine.domain.payment.service.PaymentService;
-import com.eatsfine.eatsfine.domain.user.exception.UserException;
-import com.eatsfine.eatsfine.domain.user.repository.UserRepository;
-import com.eatsfine.eatsfine.domain.user.status.UserErrorStatus;
+
 import com.eatsfine.eatsfine.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,7 +27,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 public class PaymentController {
 
     private final PaymentService paymentService;
-    private final UserRepository userRepository;
 
     @Operation(summary = "결제 요청", description = "예약 ID를 받아 주문 ID를 생성하고 결제 정보를 초기화합니다.")
     @PostMapping("/request")
@@ -55,27 +53,21 @@ public class PaymentController {
     @Operation(summary = "결제 내역 조회", description = "로그인한 사용자의 결제 내역을 조회합니다.")
     @GetMapping
     public ApiResponse<PaymentResponseDTO.PaymentListResponseDTO> getPaymentList(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal UserDetails user,
             @RequestParam(name = "page", defaultValue = "1") Integer page,
             @RequestParam(name = "limit", defaultValue = "10") Integer limit,
             @RequestParam(name = "status", required = false) String status) {
-        Long userId = getUserId(user);
-        return ApiResponse.onSuccess(paymentService.getPaymentList(userId, page, limit, status));
+        String email = user.getUsername();
+        return ApiResponse.onSuccess(paymentService.getPaymentList(email, page, limit, status));
     }
 
     @Operation(summary = "결제 상세 조회", description = "특정 결제 건의 상세 내역을 조회합니다.")
     @GetMapping("/{paymentId}")
     public ApiResponse<PaymentResponseDTO.PaymentDetailResultDTO> getPaymentDetail(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal UserDetails user,
             @PathVariable Long paymentId) {
-        Long userId = getUserId(user);
-        return ApiResponse.onSuccess(paymentService.getPaymentDetail(paymentId, userId));
+        String email = user.getUsername();
+        return ApiResponse.onSuccess(paymentService.getPaymentDetail(paymentId, email));
     }
 
-    private Long getUserId(User user) {
-        String email = user.getUsername();
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new UserException(UserErrorStatus.MEMBER_NOT_FOUND))
-                .getId();
-    }
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/repository/PaymentRepository.java
@@ -15,10 +15,10 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
         Optional<Payment> findByPaymentKey(String paymentKey);
 
-        @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store WHERE b.user.id = :userId", countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b WHERE b.user.id = :userId")
+        @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store WHERE b.user.id = :userId", countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b JOIN b.store WHERE b.user.id = :userId")
         Page<Payment> findAllByUserIdWithDetails(@Param("userId") Long userId, Pageable pageable);
 
-        @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store WHERE b.user.id = :userId AND p.paymentStatus = :status", countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b WHERE b.user.id = :userId AND p.paymentStatus = :status")
+        @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store WHERE b.user.id = :userId AND p.paymentStatus = :status", countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b JOIN b.store WHERE b.user.id = :userId AND p.paymentStatus = :status")
         Page<Payment> findAllByUserIdAndStatusWithDetails(@Param("userId") Long userId,
                         @Param("status") PaymentStatus status, Pageable pageable);
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/repository/PaymentRepository.java
@@ -11,18 +11,24 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
-    Optional<Payment> findByOrderId(String orderId);
+        Optional<Payment> findByOrderId(String orderId);
 
-    Optional<Payment> findByPaymentKey(String paymentKey);
+        Optional<Payment> findByPaymentKey(String paymentKey);
 
-    @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store WHERE b.user.id = :userId",
-            countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b WHERE b.user.id = :userId")
-    Page<Payment> findAllByUserIdWithDetails(@Param("userId") Long userId, Pageable pageable);
+        @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store WHERE b.user.id = :userId", countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b WHERE b.user.id = :userId")
+        Page<Payment> findAllByUserIdWithDetails(@Param("userId") Long userId, Pageable pageable);
 
-    @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store WHERE b.user.id = :userId AND p.paymentStatus = :status",
-            countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b WHERE b.user.id = :userId AND p.paymentStatus = :status")
-    Page<Payment> findAllByUserIdAndStatusWithDetails(@Param("userId") Long userId, @Param("status") PaymentStatus status, Pageable pageable);
+        @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store WHERE b.user.id = :userId AND p.paymentStatus = :status", countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b WHERE b.user.id = :userId AND p.paymentStatus = :status")
+        Page<Payment> findAllByUserIdAndStatusWithDetails(@Param("userId") Long userId,
+                        @Param("status") PaymentStatus status, Pageable pageable);
 
-    @Query("SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store JOIN FETCH b.user WHERE p.id = :paymentId")
-    Optional<Payment> findByIdWithDetails(@Param("paymentId") Long paymentId);
+        @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store s WHERE s.owner.id = :userId", countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b JOIN b.store s WHERE s.owner.id = :userId")
+        Page<Payment> findAllByOwnerIdWithDetails(@Param("userId") Long userId, Pageable pageable);
+
+        @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store s WHERE s.owner.id = :userId AND p.paymentStatus = :status", countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b JOIN b.store s WHERE s.owner.id = :userId AND p.paymentStatus = :status")
+        Page<Payment> findAllByOwnerIdAndStatusWithDetails(@Param("userId") Long userId,
+                        @Param("status") PaymentStatus status, Pageable pageable);
+
+        @Query("SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store JOIN FETCH b.user WHERE p.id = :paymentId")
+        Optional<Payment> findByIdWithDetails(@Param("paymentId") Long paymentId);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/repository/PaymentRepository.java
@@ -22,13 +22,13 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
         Page<Payment> findAllByUserIdAndStatusWithDetails(@Param("userId") Long userId,
                         @Param("status") PaymentStatus status, Pageable pageable);
 
-        @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store s WHERE s.owner.id = :userId", countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b JOIN b.store s WHERE s.owner.id = :userId")
-        Page<Payment> findAllByOwnerIdWithDetails(@Param("userId") Long userId, Pageable pageable);
+        @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store s WHERE s.owner.id = :ownerId", countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b JOIN b.store s WHERE s.owner.id = :ownerId")
+        Page<Payment> findAllByOwnerIdWithDetails(@Param("ownerId") Long ownerId, Pageable pageable);
 
-        @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store s WHERE s.owner.id = :userId AND p.paymentStatus = :status", countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b JOIN b.store s WHERE s.owner.id = :userId AND p.paymentStatus = :status")
-        Page<Payment> findAllByOwnerIdAndStatusWithDetails(@Param("userId") Long userId,
+        @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store s WHERE s.owner.id = :ownerId AND p.paymentStatus = :status", countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b JOIN b.store s WHERE s.owner.id = :ownerId AND p.paymentStatus = :status")
+        Page<Payment> findAllByOwnerIdAndStatusWithDetails(@Param("ownerId") Long ownerId,
                         @Param("status") PaymentStatus status, Pageable pageable);
 
-        @Query("SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store JOIN FETCH b.user WHERE p.id = :paymentId")
+        @Query("SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store s JOIN FETCH s.owner JOIN FETCH b.user WHERE p.id = :paymentId")
         Optional<Payment> findByIdWithDetails(@Param("paymentId") Long paymentId);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/repository/PaymentRepository.java
@@ -5,6 +5,8 @@ import com.eatsfine.eatsfine.domain.payment.enums.PaymentStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -13,7 +15,14 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     Optional<Payment> findByPaymentKey(String paymentKey);
 
-    Page<Payment> findAllByBooking_User_Id(Long userId, Pageable pageable);
+    @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store WHERE b.user.id = :userId",
+            countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b WHERE b.user.id = :userId")
+    Page<Payment> findAllByUserIdWithDetails(@Param("userId") Long userId, Pageable pageable);
 
-    Page<Payment> findAllByBooking_User_IdAndPaymentStatus(Long userId, PaymentStatus status, Pageable pageable);
+    @Query(value = "SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store WHERE b.user.id = :userId AND p.paymentStatus = :status",
+            countQuery = "SELECT COUNT(p) FROM Payment p JOIN p.booking b WHERE b.user.id = :userId AND p.paymentStatus = :status")
+    Page<Payment> findAllByUserIdAndStatusWithDetails(@Param("userId") Long userId, @Param("status") PaymentStatus status, Pageable pageable);
+
+    @Query("SELECT p FROM Payment p JOIN FETCH p.booking b JOIN FETCH b.store JOIN FETCH b.user WHERE p.id = :paymentId")
+    Optional<Payment> findByIdWithDetails(@Param("paymentId") Long paymentId);
 }

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/service/PaymentService.java
@@ -180,10 +180,10 @@ public class PaymentService {
                                 // 유효하지 않은 status가 들어오면 BadRequest 예외 발생
                                 throw new GeneralException(ErrorStatus._BAD_REQUEST);
                         }
-                        paymentPage = paymentRepository.findAllByBooking_User_IdAndPaymentStatus(userId, paymentStatus,
+                        paymentPage = paymentRepository.findAllByUserIdAndStatusWithDetails(userId, paymentStatus,
                                         pageable);
                 } else {
-                        paymentPage = paymentRepository.findAllByBooking_User_Id(userId, pageable);
+                        paymentPage = paymentRepository.findAllByUserIdWithDetails(userId, pageable);
                 }
 
                 List<PaymentResponseDTO.PaymentHistoryResultDTO> payments = paymentPage.getContent().stream()
@@ -212,7 +212,7 @@ public class PaymentService {
 
         @Transactional(readOnly = true)
         public PaymentResponseDTO.PaymentDetailResultDTO getPaymentDetail(Long paymentId, Long userId) {
-                Payment payment = paymentRepository.findById(paymentId)
+                Payment payment = paymentRepository.findByIdWithDetails(paymentId)
                                 .orElseThrow(() -> new PaymentException(PaymentErrorStatus._PAYMENT_NOT_FOUND));
 
                 if (!payment.getBooking().getUser().getId().equals(userId)) {

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/service/PaymentService.java
@@ -211,9 +211,13 @@ public class PaymentService {
         }
 
         @Transactional(readOnly = true)
-        public PaymentResponseDTO.PaymentDetailResultDTO getPaymentDetail(Long paymentId) {
+        public PaymentResponseDTO.PaymentDetailResultDTO getPaymentDetail(Long paymentId, Long userId) {
                 Payment payment = paymentRepository.findById(paymentId)
                                 .orElseThrow(() -> new PaymentException(PaymentErrorStatus._PAYMENT_NOT_FOUND));
+
+                if (!payment.getBooking().getUser().getId().equals(userId)) {
+                        throw new PaymentException(PaymentErrorStatus._PAYMENT_ACCESS_DENIED);
+                }
 
                 return new PaymentResponseDTO.PaymentDetailResultDTO(
                                 payment.getId(),

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/service/PaymentService.java
@@ -170,8 +170,8 @@ public class PaymentService {
                         String status) {
                 User user = userRepository.findByEmail(email)
                                 .orElseThrow(() -> new UserException(UserErrorStatus.MEMBER_NOT_FOUND));
-                // limit 기본값 처리 (만약 null이면 10)
-                int size = (limit != null) ? limit : 10;
+                // limit 기본값 처리 (null이거나 0 이하이면 10)
+                int size = (limit != null && limit > 0) ? limit : 10;
                 // page 기본값 처리 (만약 null이면 1, 0보다 작으면 1로 보정). Spring Data는 0-based index이므로 -1
                 int pageNumber = (page != null && page > 0) ? page - 1 : 0;
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/service/PaymentService.java
@@ -12,11 +12,16 @@ import com.eatsfine.eatsfine.domain.payment.enums.PaymentMethod;
 import com.eatsfine.eatsfine.domain.payment.enums.PaymentProvider;
 import com.eatsfine.eatsfine.domain.payment.enums.PaymentStatus;
 import com.eatsfine.eatsfine.domain.payment.enums.PaymentType;
+import com.eatsfine.eatsfine.domain.user.entity.User;
+import com.eatsfine.eatsfine.domain.user.enums.Role;
 import com.eatsfine.eatsfine.domain.payment.repository.PaymentRepository;
 import com.eatsfine.eatsfine.domain.payment.exception.PaymentException;
 import com.eatsfine.eatsfine.domain.payment.status.PaymentErrorStatus;
 import com.eatsfine.eatsfine.global.apiPayload.code.status.ErrorStatus;
 import com.eatsfine.eatsfine.global.apiPayload.exception.GeneralException;
+import com.eatsfine.eatsfine.domain.user.repository.UserRepository;
+import com.eatsfine.eatsfine.domain.user.exception.UserException;
+import com.eatsfine.eatsfine.domain.user.status.UserErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -38,6 +43,7 @@ public class PaymentService {
 
         private final PaymentRepository paymentRepository;
         private final BookingRepository bookingRepository;
+        private final UserRepository userRepository;
         private final TossPaymentService tossPaymentService;
 
         @Transactional
@@ -122,7 +128,6 @@ public class PaymentService {
                         log.info("Booking confirmed for OrderID: {}", dto.orderId());
                 }
 
-
                 log.info("Payment confirmed for OrderID: {}", dto.orderId());
 
                 return new PaymentResponseDTO.PaymentSuccessResultDTO(
@@ -135,7 +140,6 @@ public class PaymentService {
                                 payment.getPaymentProvider() != null ? payment.getPaymentProvider().name() : null,
                                 payment.getReceiptUrl());
         }
-
 
         @Transactional(noRollbackFor = GeneralException.class)
         public PaymentResponseDTO.CancelPaymentResultDTO cancelPayment(String paymentKey,
@@ -162,8 +166,10 @@ public class PaymentService {
         }
 
         @Transactional(readOnly = true)
-        public PaymentResponseDTO.PaymentListResponseDTO getPaymentList(Long userId, Integer page, Integer limit,
+        public PaymentResponseDTO.PaymentListResponseDTO getPaymentList(String email, Integer page, Integer limit,
                         String status) {
+                User user = userRepository.findByEmail(email)
+                                .orElseThrow(() -> new UserException(UserErrorStatus.MEMBER_NOT_FOUND));
                 // limit 기본값 처리 (만약 null이면 10)
                 int size = (limit != null) ? limit : 10;
                 // page 기본값 처리 (만약 null이면 1, 0보다 작으면 1로 보정). Spring Data는 0-based index이므로 -1
@@ -172,18 +178,32 @@ public class PaymentService {
                 Pageable pageable = PageRequest.of(pageNumber, size);
 
                 Page<Payment> paymentPage;
-                if (status != null && !status.isEmpty()) {
-                        PaymentStatus paymentStatus;
-                        try {
-                                paymentStatus = PaymentStatus.valueOf(status.toUpperCase());
-                        } catch (IllegalArgumentException e) {
-                                // 유효하지 않은 status가 들어오면 BadRequest 예외 발생
-                                throw new GeneralException(ErrorStatus._BAD_REQUEST);
+                if (user.getRole() == Role.ROLE_OWNER) {
+                        if (status != null && !status.isEmpty()) {
+                                PaymentStatus paymentStatus;
+                                try {
+                                        paymentStatus = PaymentStatus.valueOf(status.toUpperCase());
+                                } catch (IllegalArgumentException e) {
+                                        throw new GeneralException(ErrorStatus._BAD_REQUEST);
+                                }
+                                paymentPage = paymentRepository.findAllByOwnerIdAndStatusWithDetails(user.getId(),
+                                                paymentStatus, pageable);
+                        } else {
+                                paymentPage = paymentRepository.findAllByOwnerIdWithDetails(user.getId(), pageable);
                         }
-                        paymentPage = paymentRepository.findAllByUserIdAndStatusWithDetails(userId, paymentStatus,
-                                        pageable);
                 } else {
-                        paymentPage = paymentRepository.findAllByUserIdWithDetails(userId, pageable);
+                        if (status != null && !status.isEmpty()) {
+                                PaymentStatus paymentStatus;
+                                try {
+                                        paymentStatus = PaymentStatus.valueOf(status.toUpperCase());
+                                } catch (IllegalArgumentException e) {
+                                        throw new GeneralException(ErrorStatus._BAD_REQUEST);
+                                }
+                                paymentPage = paymentRepository.findAllByUserIdAndStatusWithDetails(user.getId(),
+                                                paymentStatus, pageable);
+                        } else {
+                                paymentPage = paymentRepository.findAllByUserIdWithDetails(user.getId(), pageable);
+                        }
                 }
 
                 List<PaymentResponseDTO.PaymentHistoryResultDTO> payments = paymentPage.getContent().stream()
@@ -211,11 +231,16 @@ public class PaymentService {
         }
 
         @Transactional(readOnly = true)
-        public PaymentResponseDTO.PaymentDetailResultDTO getPaymentDetail(Long paymentId, Long userId) {
+        public PaymentResponseDTO.PaymentDetailResultDTO getPaymentDetail(Long paymentId, String email) {
+                User user = userRepository.findByEmail(email)
+                                .orElseThrow(() -> new UserException(UserErrorStatus.MEMBER_NOT_FOUND));
                 Payment payment = paymentRepository.findByIdWithDetails(paymentId)
                                 .orElseThrow(() -> new PaymentException(PaymentErrorStatus._PAYMENT_NOT_FOUND));
 
-                if (!payment.getBooking().getUser().getId().equals(userId)) {
+                boolean isBooker = payment.getBooking().getUser().getId().equals(user.getId());
+                boolean isStoreOwner = payment.getBooking().getStore().getOwner().getId().equals(user.getId());
+
+                if (!isBooker && !isStoreOwner) {
                         throw new PaymentException(PaymentErrorStatus._PAYMENT_ACCESS_DENIED);
                 }
 

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/service/PaymentService.java
@@ -323,7 +323,7 @@ public class PaymentService {
         }
 
         private PaymentStatus parsePaymentStatus(String status) {
-                if (status == null || status.isEmpty()) {
+                if (status == null || status.isBlank()) {
                         return null;
                 }
                 try {

--- a/src/main/java/com/eatsfine/eatsfine/domain/payment/status/PaymentErrorStatus.java
+++ b/src/main/java/com/eatsfine/eatsfine/domain/payment/status/PaymentErrorStatus.java
@@ -13,7 +13,8 @@ public enum PaymentErrorStatus implements BaseErrorCode {
     _PAYMENT_INVALID_DEPOSIT(HttpStatus.BAD_REQUEST, "PAYMENT4001", "예약금이 유효하지 않습니다."),
     _PAYMENT_INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "PAYMENT4002", "결제 금액이 일치하지 않습니다."),
     _PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT4003", "결제 정보를 찾을 수 없습니다."),
-    _BOOKING_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKING4001", "예약을 찾을 수 없습니다.");
+    _BOOKING_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKING4001", "예약을 찾을 수 없습니다."),
+    _PAYMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "PAYMENT4031", "해당 결제 정보에 접근할 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -60,14 +60,16 @@ spring:
 
 payment:
   toss:
-    widget-secret-key: test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6
+    widget-secret-key: ${TOSS_WIDGET_SECRET_KEY}
 
 cloud:
   aws:
-    region: ap-northeast-2
+    region: ${AWS_REGION}
     s3:
-      bucket: eatsfine-images
-      base-url: https://eatsfine-images.s3.ap-northeast-2.amazonaws.com
+      bucket: ${AWS_S3_BUCKET}
+      base-url: ${AWS_S3_BASE_URL}
 
+api:
+  service-key: ${BIZ_API_KEY}
 jwt:
   secret: ${SECRET_KEY}

--- a/src/test/java/com/eatsfine/eatsfine/controller/HealthControllerTest.java
+++ b/src/test/java/com/eatsfine/eatsfine/controller/HealthControllerTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -41,13 +41,13 @@ class HealthControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    @MockBean
+    @MockitoBean
     private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
-    @MockBean
+    @MockitoBean
     private CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @BeforeEach

--- a/src/test/java/com/eatsfine/eatsfine/domain/inquiry/controller/InquiryControllerTest.java
+++ b/src/test/java/com/eatsfine/eatsfine/domain/inquiry/controller/InquiryControllerTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -42,16 +42,16 @@ class InquiryControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private InquiryService inquiryService;
 
-    @MockBean
+    @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    @MockBean
+    @MockitoBean
     private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
-    @MockBean
+    @MockitoBean
     private CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Autowired

--- a/src/test/java/com/eatsfine/eatsfine/domain/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/com/eatsfine/eatsfine/domain/payment/controller/PaymentControllerTest.java
@@ -1,0 +1,187 @@
+package com.eatsfine.eatsfine.domain.payment.controller;
+
+import com.eatsfine.eatsfine.domain.payment.dto.request.PaymentConfirmDTO;
+import com.eatsfine.eatsfine.domain.payment.dto.request.PaymentRequestDTO;
+import com.eatsfine.eatsfine.domain.payment.dto.response.PaymentResponseDTO;
+import com.eatsfine.eatsfine.domain.payment.service.PaymentService;
+import com.eatsfine.eatsfine.global.auth.CustomAccessDeniedHandler;
+import com.eatsfine.eatsfine.global.auth.CustomAuthenticationEntryPoint;
+import com.eatsfine.eatsfine.global.config.jwt.JwtAuthenticationFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PaymentController.class)
+@WithMockUser
+class PaymentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PaymentService paymentService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @MockBean
+    private CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() throws ServletException, IOException {
+        doAnswer(invocation -> {
+            HttpServletRequest request = invocation.getArgument(0);
+            HttpServletResponse response = invocation.getArgument(1);
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(request, response);
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class),
+                any(FilterChain.class));
+    }
+
+    @Test
+    @DisplayName("결제 요청 성공")
+    void requestPayment_success() throws Exception {
+        // given
+        PaymentRequestDTO.RequestPaymentDTO request = new PaymentRequestDTO.RequestPaymentDTO(1L);
+        PaymentResponseDTO.PaymentRequestResultDTO response = new PaymentResponseDTO.PaymentRequestResultDTO(
+                1L, 1L, "order-id-123", BigDecimal.valueOf(10000), LocalDateTime.now());
+
+        given(paymentService.requestPayment(any(PaymentRequestDTO.RequestPaymentDTO.class))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/payments/request")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.paymentId").value(1L))
+                .andExpect(jsonPath("$.result.orderId").value("order-id-123"));
+    }
+
+    @Test
+    @DisplayName("결제 승인 성공")
+    void confirmPayment_success() throws Exception {
+        // given
+        PaymentConfirmDTO request = PaymentConfirmDTO.builder()
+                .paymentKey("payment-key-123")
+                .orderId("order-id-123")
+                .amount(BigDecimal.valueOf(10000))
+                .build();
+
+        PaymentResponseDTO.PaymentSuccessResultDTO response = new PaymentResponseDTO.PaymentSuccessResultDTO(
+                1L, "COMPLETED", LocalDateTime.now(), "order-id-123", BigDecimal.valueOf(10000),
+                "CARD", "TOSS", "http://receipt.url");
+
+        given(paymentService.confirmPayment(any(PaymentConfirmDTO.class))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/payments/confirm")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.status").value("COMPLETED"));
+    }
+
+    @Test
+    @DisplayName("결제 취소 성공")
+    void cancelPayment_success() throws Exception {
+        // given
+        String paymentKey = "payment-key-123";
+        PaymentRequestDTO.CancelPaymentDTO request = new PaymentRequestDTO.CancelPaymentDTO("단순 변심");
+        PaymentResponseDTO.CancelPaymentResultDTO response = new PaymentResponseDTO.CancelPaymentResultDTO(
+                1L, "order-id-123", paymentKey, "CANCELED", LocalDateTime.now());
+
+        given(paymentService.cancelPayment(eq(paymentKey), any(PaymentRequestDTO.CancelPaymentDTO.class)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/payments/{paymentKey}/cancel", paymentKey)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.status").value("CANCELED"));
+    }
+
+    @Test
+    @DisplayName("결제 내역 조회 성공")
+    void getPaymentList_success() throws Exception {
+        // given
+        PaymentResponseDTO.PaginationDTO pagination = new PaymentResponseDTO.PaginationDTO(1, 1, 1L);
+        PaymentResponseDTO.PaymentHistoryResultDTO history = new PaymentResponseDTO.PaymentHistoryResultDTO(
+                1L, 1L, "Store Name", BigDecimal.valueOf(10000), "DEPOSIT", "CARD", "TOSS", "COMPLETED",
+                LocalDateTime.now());
+        PaymentResponseDTO.PaymentListResponseDTO response = new PaymentResponseDTO.PaymentListResponseDTO(
+                Collections.singletonList(history), pagination);
+
+        given(paymentService.getPaymentList(any(Long.class), any(Integer.class), any(Integer.class), any()))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/payments")
+                .param("page", "1")
+                .param("limit", "10")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.payments[0].storeName").value("Store Name"));
+    }
+
+    @Test
+    @DisplayName("결제 상세 조회 성공")
+    void getPaymentDetail_success() throws Exception {
+        // given
+        Long paymentId = 1L;
+        PaymentResponseDTO.PaymentDetailResultDTO response = new PaymentResponseDTO.PaymentDetailResultDTO(
+                paymentId, 1L, "Store Name", "CARD", "TOSS", BigDecimal.valueOf(10000), "DEPOSIT",
+                "COMPLETED", LocalDateTime.now(), LocalDateTime.now(), "http://receipt.url", null);
+
+        given(paymentService.getPaymentDetail(eq(paymentId))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/payments/{paymentId}", paymentId)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.paymentId").value(paymentId));
+    }
+}

--- a/src/test/java/com/eatsfine/eatsfine/domain/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/com/eatsfine/eatsfine/domain/payment/controller/PaymentControllerTest.java
@@ -4,9 +4,6 @@ import com.eatsfine.eatsfine.domain.payment.dto.request.PaymentConfirmDTO;
 import com.eatsfine.eatsfine.domain.payment.dto.request.PaymentRequestDTO;
 import com.eatsfine.eatsfine.domain.payment.dto.response.PaymentResponseDTO;
 import com.eatsfine.eatsfine.domain.payment.service.PaymentService;
-import com.eatsfine.eatsfine.domain.user.entity.User;
-import com.eatsfine.eatsfine.domain.user.enums.Role;
-import com.eatsfine.eatsfine.domain.user.repository.UserRepository;
 import com.eatsfine.eatsfine.global.auth.CustomAccessDeniedHandler;
 import com.eatsfine.eatsfine.global.auth.CustomAuthenticationEntryPoint;
 import com.eatsfine.eatsfine.global.config.jwt.JwtAuthenticationFilter;
@@ -20,7 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -29,8 +26,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -50,20 +45,17 @@ class PaymentControllerTest {
         @Autowired
         private MockMvc mockMvc;
 
-        @MockBean
+        @MockitoBean
         private PaymentService paymentService;
 
-        @MockBean
+        @MockitoBean
         private JwtAuthenticationFilter jwtAuthenticationFilter;
 
-        @MockBean
+        @MockitoBean
         private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
-        @MockBean
+        @MockitoBean
         private CustomAccessDeniedHandler customAccessDeniedHandler;
-
-        @MockBean
-        private UserRepository userRepository;
 
         @Autowired
         private ObjectMapper objectMapper;
@@ -161,10 +153,7 @@ class PaymentControllerTest {
                 PaymentResponseDTO.PaymentListResponseDTO response = new PaymentResponseDTO.PaymentListResponseDTO(
                                 Collections.singletonList(history), pagination);
 
-                User user = User.builder().id(1L).email("user").role(Role.ROLE_CUSTOMER).build();
-                given(userRepository.findByEmail("user")).willReturn(Optional.of(user));
-
-                given(paymentService.getPaymentList(eq(1L), any(Integer.class), any(Integer.class), any()))
+                given(paymentService.getPaymentList(anyString(), any(Integer.class), any(Integer.class), any()))
                                 .willReturn(response);
 
                 // when & then
@@ -186,10 +175,7 @@ class PaymentControllerTest {
                                 paymentId, 1L, "Store Name", "CARD", "TOSS", BigDecimal.valueOf(10000), "DEPOSIT",
                                 "COMPLETED", LocalDateTime.now(), LocalDateTime.now(), "http://receipt.url", null);
 
-                User user = User.builder().id(1L).email("user").role(Role.ROLE_CUSTOMER).build();
-                given(userRepository.findByEmail("user")).willReturn(Optional.of(user));
-
-                given(paymentService.getPaymentDetail(eq(paymentId), eq(1L))).willReturn(response);
+                given(paymentService.getPaymentDetail(eq(paymentId), anyString())).willReturn(response);
 
                 // when & then
                 mockMvc.perform(get("/api/v1/payments/{paymentId}", paymentId)

--- a/src/test/java/com/eatsfine/eatsfine/domain/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/com/eatsfine/eatsfine/domain/payment/controller/PaymentControllerTest.java
@@ -236,11 +236,10 @@ class PaymentControllerTest {
                                 .content(objectMapper.writeValueAsString(request)))
                                 .andExpect(status().isNotFound())
                                 .andExpect(jsonPath("$.isSuccess").value(false))
-                                .andExpect(jsonPath("$.code").value("BOOKING4001"));
+                                .andExpect(jsonPath("$.code").value(PaymentErrorStatus._BOOKING_NOT_FOUND.getCode()));
         }
 
         @Test
-        @WithMockUser(roles = {}) // 인증되지 않은 사용자 시뮬레이션 (빈 권한)
         @DisplayName("결제 내역 조회 실패 - 서비스에서 UserException 발생 시 에러 응답")
         void getPaymentList_fail_serviceException() throws Exception {
                 // given

--- a/src/test/java/com/eatsfine/eatsfine/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/eatsfine/eatsfine/domain/payment/service/PaymentServiceTest.java
@@ -1,0 +1,218 @@
+package com.eatsfine.eatsfine.domain.payment.service;
+
+import com.eatsfine.eatsfine.domain.booking.entity.Booking;
+import com.eatsfine.eatsfine.domain.booking.repository.BookingRepository;
+import com.eatsfine.eatsfine.domain.payment.dto.request.PaymentConfirmDTO;
+import com.eatsfine.eatsfine.domain.payment.dto.request.PaymentRequestDTO;
+import com.eatsfine.eatsfine.domain.payment.dto.response.PaymentResponseDTO;
+import com.eatsfine.eatsfine.domain.payment.dto.response.TossPaymentResponse;
+import com.eatsfine.eatsfine.domain.payment.entity.Payment;
+import com.eatsfine.eatsfine.domain.payment.enums.PaymentMethod;
+import com.eatsfine.eatsfine.domain.payment.enums.PaymentProvider;
+import com.eatsfine.eatsfine.domain.payment.enums.PaymentStatus;
+import com.eatsfine.eatsfine.domain.payment.enums.PaymentType;
+import com.eatsfine.eatsfine.domain.payment.exception.PaymentException;
+import com.eatsfine.eatsfine.domain.payment.repository.PaymentRepository;
+import com.eatsfine.eatsfine.domain.store.entity.Store;
+import com.eatsfine.eatsfine.domain.payment.status.PaymentErrorStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+        @InjectMocks
+        private PaymentService paymentService;
+
+        @Mock
+        private PaymentRepository paymentRepository;
+
+        @Mock
+        private BookingRepository bookingRepository;
+
+        @Mock
+        private TossPaymentService tossPaymentService;
+
+        @Test
+        @DisplayName("결제 요청 성공")
+        void requestPayment_success() {
+                // given
+                Long bookingId = 1L;
+                PaymentRequestDTO.RequestPaymentDTO request = new PaymentRequestDTO.RequestPaymentDTO(bookingId);
+
+                Booking booking = Booking.builder()
+                                .id(bookingId)
+                                .build();
+                ReflectionTestUtils.setField(booking, "depositAmount", BigDecimal.valueOf(10000));
+
+                Payment payment = Payment.builder()
+                                .id(1L)
+                                .booking(booking)
+                                .amount(BigDecimal.valueOf(10000))
+                                .orderId("generated-order-id")
+                                .paymentStatus(PaymentStatus.PENDING)
+                                .requestedAt(LocalDateTime.now())
+                                .build();
+
+                given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
+                given(paymentRepository.save(any(Payment.class))).willReturn(payment);
+
+                // when
+                PaymentResponseDTO.PaymentRequestResultDTO response = paymentService.requestPayment(request);
+
+                // then
+                assertThat(response.amount()).isEqualTo(BigDecimal.valueOf(10000));
+                assertThat(response.orderId()).isEqualTo("generated-order-id");
+                verify(paymentRepository, times(1)).save(any(Payment.class));
+        }
+
+        @Test
+        @DisplayName("결제 요청 실패 - 예약 없음")
+        void requestPayment_fail_bookingNotFound() {
+                // given
+                PaymentRequestDTO.RequestPaymentDTO request = new PaymentRequestDTO.RequestPaymentDTO(999L);
+                given(bookingRepository.findById(999L)).willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() -> paymentService.requestPayment(request))
+                                .isInstanceOf(PaymentException.class)
+                                .extracting("code")
+                                .isEqualTo(PaymentErrorStatus._BOOKING_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("결제 승인 성공")
+        void confirmPayment_success() {
+                // given
+                String orderId = "order-id-123";
+                String paymentKey = "payment-key-123";
+                BigDecimal amount = BigDecimal.valueOf(10000);
+                PaymentConfirmDTO request = PaymentConfirmDTO.builder()
+                                .orderId(orderId)
+                                .amount(amount)
+                                .paymentKey(paymentKey)
+                                .build();
+
+                Booking booking = Booking.builder().id(1L).build();
+                Payment payment = Payment.builder()
+                                .id(1L)
+                                .booking(booking)
+                                .orderId(orderId)
+                                .amount(amount)
+                                .paymentStatus(PaymentStatus.PENDING)
+                                .build();
+
+                TossPaymentResponse.EasyPay easyPay = new TossPaymentResponse.EasyPay("토스페이", 10000, 0);
+                TossPaymentResponse tossResponse = new TossPaymentResponse(
+                                paymentKey, "NORMAL", orderId, "orderName", "mId", "KRW", "CARD",
+                                10000, 10000, "DONE",
+                                java.time.OffsetDateTime.now(), java.time.OffsetDateTime.now(),
+                                false, null, 10000, 0,
+                                easyPay, new TossPaymentResponse.Receipt("http://receipt.url"));// TossPaymentResponse
+                                                                                                // record 생성자가 많아서
+                                                                                                // 필드에 맞게 넣어줌 (가정)
+                                                                                                // 실제 record 구조에 따라 맞춰야
+                                                                                                // 함. 위 내용은 예시.
+                                                                                                // TossPaymentResponse가
+                                                                                                // record이므로 생성자
+                                                                                                // 파라미터 순서 중요.
+                                                                                                // 여기서는 Mocking을 하거나,
+                                                                                                // 필드가 많으면 빌더나 생성자를
+                                                                                                // 확인해야 함.
+                                                                                                // TossPaymentService가
+                                                                                                // Mock이므로 response
+                                                                                                // 리턴값만 잘 맞춰주면 됨.
+
+                given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(payment));
+                given(tossPaymentService.confirm(any(PaymentConfirmDTO.class))).willReturn(tossResponse);
+
+                // when
+                PaymentResponseDTO.PaymentSuccessResultDTO response = paymentService.confirmPayment(request);
+
+                // then
+                assertThat(response.status()).isEqualTo(PaymentStatus.COMPLETED.name());
+                assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("결제 승인 실패 - 금액 불일치")
+        void confirmPayment_fail_invalidAmount() {
+                // given
+                String orderId = "order-id-123";
+                BigDecimal originalAmount = BigDecimal.valueOf(10000);
+                BigDecimal requestAmount = BigDecimal.valueOf(5000); // Mismatch
+
+                PaymentConfirmDTO request = PaymentConfirmDTO.builder()
+                                .orderId(orderId)
+                                .amount(requestAmount)
+                                .paymentKey("key")
+                                .build();
+
+                Payment payment = Payment.builder()
+                                .id(1L)
+                                .orderId(orderId)
+                                .amount(originalAmount)
+                                .paymentStatus(PaymentStatus.PENDING)
+                                .build();
+
+                given(paymentRepository.findByOrderId(orderId)).willReturn(Optional.of(payment));
+
+                // when & then
+                assertThatThrownBy(() -> paymentService.confirmPayment(request))
+                                .isInstanceOf(PaymentException.class)
+                                .extracting("code")
+                                .isEqualTo(PaymentErrorStatus._PAYMENT_INVALID_AMOUNT);
+
+                assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.FAILED);
+        }
+
+        @Test
+        @DisplayName("결제 취소 성공")
+        void cancelPayment_success() {
+                // given
+                String paymentKey = "payment-key-123";
+                PaymentRequestDTO.CancelPaymentDTO request = new PaymentRequestDTO.CancelPaymentDTO("단순 변심");
+
+                Payment payment = Payment.builder()
+                                .id(1L)
+                                .paymentKey(paymentKey)
+                                .orderId("order-id-123")
+                                .paymentStatus(PaymentStatus.COMPLETED)
+                                .build();
+
+                TossPaymentResponse tossResponse = new TossPaymentResponse(
+                                paymentKey, "NORMAL", "order-id-123", "orderName", "mId", "KRW", "CARD",
+                                10000, 0, "CANCELED",
+                                java.time.OffsetDateTime.now(), java.time.OffsetDateTime.now(),
+                                false, null, 10000, 0,
+                                null, null);
+                given(paymentRepository.findByPaymentKey(paymentKey)).willReturn(Optional.of(payment));
+                given(tossPaymentService.cancel(eq(paymentKey), any(PaymentRequestDTO.CancelPaymentDTO.class)))
+                                .willReturn(tossResponse);
+
+                // when
+                PaymentResponseDTO.CancelPaymentResultDTO response = paymentService.cancelPayment(paymentKey, request);
+
+                // then
+                assertThat(response.status()).isEqualTo("REFUNDED");
+                assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.REFUNDED);
+        }
+}


### PR DESCRIPTION
### 💡 작업 개요
- 결제(Payment) 도메인의 안정성을 확보하기 위해 Controller와 Service 계층의 단위 테스트 코드를 작성했습니다.
- 민감한 키 값 환경변수화했습니다.
- 인증되지 않은 요청이나 다른 사용자의 결제 내역에 접근하는 시도가 차단됩니다.
- 결제 내역 조회 시 발생할 수 있는 N+1 문제를 해결하고, 다른 사용자의 결제 내역을 조회할 수 없도록 보안 로직을 강화했습니다.

### ✅ 작업 내용
- [x] 기능 개발
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 주석/포맷 정리
- [x] 기타 설정

### 🧪 테스트 내용
- JUnit 5 & Mockito를 사용하여 단위 테스트 진행
- ./gradlew test 실행 결과 모든 테스트 통과

### 📝 기타 참고 사항
- N+1 문제 해결: 기존에는 결제 내역 조회 후 예약 정보(Booking), 가게 정보(Store)를 접근할 때마다 추가 쿼리가 발생할 수 있었으나, JOIN FETCH를 통해 한 번의 쿼리로 데이터를 가져오도록 최적화했습니다.
- 보안 강화: getPaymentDetail 에서 소유권 검증 로직을 서비스 단에서 강제함으로써, ID만 알면 다른 사람의 결제 내역을 볼 수 있는 보안 취약점을 예방했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인증된 사용자(이메일) 컨텍스트로 결제 목록/상세 조회 동작 변경

* **개선사항**
  * 사용자 역할(점주/고객) 기반 조회 분기 및 관련 연관정보 로딩 개선
  * 결제 접근 권한 제어 및 접근거부 오류 추가

* **테스트**
  * 결제 컨트롤러·서비스에 대한 단위/통합 테스트 대규모 추가
  * 테스트 모킹 방식 일부 개선

* **기타**
  * 로컬 설정을 환경변수 기반으로 전환, .env 예시·무시 규칙 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->