### PR TITLE
[FIX]: 예약 내역 조회 에러 Transactional(readOnly = true) 어노테이션 추가

### DIFF
--- a/src/main/java/com/eatsfine/domain/booking/service/BookingQueryServiceImpl.java
+++ b/src/main/java/com/eatsfine/domain/booking/service/BookingQueryServiceImpl.java
@@ -171,6 +171,7 @@ public class BookingQueryServiceImpl implements BookingQueryService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public BookingResponseDTO.BookingPreviewListDTO getBookingList(Long userId, String status, Integer page) {
         PageRequest pageRequest = PageRequest.of(page, 10, Sort.by("bookingDate").descending());
 


### PR DESCRIPTION
### 💡 작업 개요
- 예약 내역 조회 API에서 발생하는 500 에러를 수정했습니다. BookingQueryServiceImpl.getBookingList() 메서드에 누락된 @Transactional 어노테이션을 추가하여 LAZY 로딩 시 발생하는LazyInitializationException을 해결했습니다.

### ✅ 작업 내용
- [ ] 기능 개발
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 주석/포맷 정리
- [ ] 기타 설정

### 🧪 테스트 내용
- 서버 재시작 후 GET /api/v1/users/bookings API 정상 작동 확인 필요

### 📝 기타 참고 사항
- 근본 원인: Git 히스토리 확인 결과, 해당 메서드는 커밋 e53a892에서 처음 작성될 때부터 @Transactional 어노테이션이 누락되어 있었습니다.
  - 이전에 작동한 이유: Spring Boot의 open-in-view 기본 설정으로 인해 HTTP 요청이 끝날 때까지 JPA 세션이 유지되었거나, 실제 예약 데이터가 없어서 LAZY 로딩이 실행되지 않았을 가능성이 있습니다.
  - 수정 파일: src/main/java/com/eatsfine/domain/booking/service/BookingQueryServiceImpl.java:174
  - 일관성: 같은 클래스 내 다른 조회 메서드들(getAvailableTimeSlots, getAvailableTables, getBookingDetail)은 모두 @Transactional(readOnly = true)를 사용하고 있어 일관성을 맞췄습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터 조회 성능 최적화를 위한 내부 개선 사항이 적용되었습니다.

---

**참고:** 이번 업데이트는 사용자에게 보이는 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->