### PR TITLE
[fix] 예약/결제 동시성 취약점 수정 (레이스 컨디션 및 오버부킹)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
 
     // WebFlux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // Flyway (MySQL)
+    implementation 'org.flywaydb:flyway-mysql'
 }
 // --- QueryDSL ---
 def generated = 'build/generated/sources/annotationProcessor/java/main'

--- a/src/main/java/com/eatsfine/domain/booking/entity/Booking.java
+++ b/src/main/java/com/eatsfine/domain/booking/entity/Booking.java
@@ -34,6 +34,9 @@ public class Booking extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -87,6 +90,8 @@ public class Booking extends BaseEntity {
         BookingTable bookingTable = BookingTable.builder()
                 .booking(this)
                 .storeTable(storeTable)
+                .bookingDate(this.bookingDate)
+                .bookingTime(this.bookingTime)
                 .build();
         this.bookingTables.add(bookingTable);
     }

--- a/src/main/java/com/eatsfine/domain/booking/entity/Booking.java
+++ b/src/main/java/com/eatsfine/domain/booking/entity/Booking.java
@@ -104,10 +104,12 @@ public class Booking extends BaseEntity {
         this.status = BookingStatus.CONFIRMED;
     }
 
-    public void cancel(String cancelReason)
-    {
+    public void cancel(String cancelReason) {
         this.status = BookingStatus.CANCELED;
         this.cancelReason = cancelReason;
+        // 유니크 제약 해제: 취소된 예약의 테이블 점유를 풀어 동일 시간대 재예약 허용
+        // orphanRemoval = true이므로 리스트 비우면 DB에서 자동 삭제됨
+        this.bookingTables.clear();
     }
 
     //예약과 관련된 결제 중 결제 완료된 결제키 조회

--- a/src/main/java/com/eatsfine/domain/booking/entity/Booking.java
+++ b/src/main/java/com/eatsfine/domain/booking/entity/Booking.java
@@ -107,9 +107,9 @@ public class Booking extends BaseEntity {
     public void cancel(String cancelReason) {
         this.status = BookingStatus.CANCELED;
         this.cancelReason = cancelReason;
-        // 유니크 제약 해제: 취소된 예약의 테이블 점유를 풀어 동일 시간대 재예약 허용
-        // orphanRemoval = true이므로 리스트 비우면 DB에서 자동 삭제됨
-        this.bookingTables.clear();
+        // BookingTable 행은 보존하되 is_active를 null로 설정하여 슬롯만 해제
+        // MySQL 유니크 인덱스는 NULL을 중복으로 취급하지 않으므로 동일 시간대 재예약 허용
+        this.bookingTables.forEach(BookingTable::deactivate);
     }
 
     //예약과 관련된 결제 중 결제 완료된 결제키 조회

--- a/src/main/java/com/eatsfine/domain/booking/entity/mapping/BookingTable.java
+++ b/src/main/java/com/eatsfine/domain/booking/entity/mapping/BookingTable.java
@@ -5,11 +5,21 @@ import com.eatsfine.domain.storetable.entity.StoreTable;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Getter
+@Table(
+    name = "booking_table",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uq_booking_table_slot",
+        columnNames = {"store_table_id", "booking_date", "booking_time"}
+    )
+)
 public class BookingTable {
 
     @Id
@@ -23,4 +33,11 @@ public class BookingTable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "booking_id")
     private Booking booking;
+
+    // 유니크 제약 적용을 위해 Booking의 날짜/시간을 비정규화하여 저장
+    @Column(name = "booking_date", nullable = false)
+    private LocalDate bookingDate;
+
+    @Column(name = "booking_time", nullable = false)
+    private LocalTime bookingTime;
 }

--- a/src/main/java/com/eatsfine/domain/booking/entity/mapping/BookingTable.java
+++ b/src/main/java/com/eatsfine/domain/booking/entity/mapping/BookingTable.java
@@ -17,7 +17,7 @@ import java.time.LocalTime;
     name = "booking_table",
     uniqueConstraints = @UniqueConstraint(
         name = "uq_booking_table_slot",
-        columnNames = {"store_table_id", "booking_date", "booking_time"}
+        columnNames = {"store_table_id", "booking_date", "booking_time", "is_active"}
     )
 )
 public class BookingTable {
@@ -40,4 +40,13 @@ public class BookingTable {
 
     @Column(name = "booking_time", nullable = false)
     private LocalTime bookingTime;
+
+    // true = 활성 예약 슬롯 (유니크 제약 적용)
+    // null = 취소된 슬롯 — MySQL은 NULL을 유니크 인덱스에서 중복으로 보지 않으므로 동일 시간대 재예약 허용
+    @Column(name = "is_active")
+    private Boolean isActive = true;
+
+    public void deactivate() {
+        this.isActive = null;
+    }
 }

--- a/src/main/java/com/eatsfine/domain/booking/exception/BookingException.java
+++ b/src/main/java/com/eatsfine/domain/booking/exception/BookingException.java
@@ -7,4 +7,8 @@ public class BookingException extends GeneralException {
     public BookingException(BaseErrorCode code) {
         super(code);
     }
+
+    public BookingException(BaseErrorCode code, Throwable cause) {
+        super(code, cause);
+    }
 }

--- a/src/main/java/com/eatsfine/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/eatsfine/domain/booking/repository/BookingRepository.java
@@ -8,8 +8,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -69,6 +72,10 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
     List<Booking> findActiveBookingsByTableAndDate(
             @Param("tableId") Long tableId,
             @Param("date") LocalDate date);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT b FROM Booking b WHERE b.id = :id")
+    Optional<Booking> findByIdWithLock(@Param("id") Long id);
 
     Optional<Booking> findByIdAndStatus(Long bookingId, BookingStatus status);
 

--- a/src/main/java/com/eatsfine/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/eatsfine/domain/booking/repository/BookingRepository.java
@@ -87,6 +87,10 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
      */
     List<Booking> findAllByStatusAndCreatedAtBefore(BookingStatus status, LocalDateTime threshold);
 
+    @Query("SELECT b.id FROM Booking b WHERE b.status = :status AND b.createdAt < :threshold")
+    List<Long> findIdsByStatusAndCreatedAtBefore(@Param("status") BookingStatus status,
+                                                 @Param("threshold") LocalDateTime threshold);
+
 
     /**
      * 특정 식당의 브레이크 타임과 겹치는 가장 늦은 예약 날짜를 조회합니다.

--- a/src/main/java/com/eatsfine/domain/booking/service/BookingCancelExecutor.java
+++ b/src/main/java/com/eatsfine/domain/booking/service/BookingCancelExecutor.java
@@ -20,10 +20,7 @@ public class BookingCancelExecutor {
 
     @Transactional(readOnly = true)
     public List<Long> findExpiredPendingIds(LocalDateTime threshold) {
-        return bookingRepository.findAllByStatusAndCreatedAtBefore(BookingStatus.PENDING, threshold)
-                .stream()
-                .map(booking -> booking.getId())
-                .toList();
+        return bookingRepository.findIdsByStatusAndCreatedAtBefore(BookingStatus.PENDING, threshold);
     }
 
     // REQUIRES_NEW: 호출마다 독립 트랜잭션 — 하나 실패해도 다른 예약에 영향 없음

--- a/src/main/java/com/eatsfine/domain/booking/service/BookingCancelExecutor.java
+++ b/src/main/java/com/eatsfine/domain/booking/service/BookingCancelExecutor.java
@@ -27,13 +27,18 @@ public class BookingCancelExecutor {
     }
 
     // REQUIRES_NEW: 호출마다 독립 트랜잭션 — 하나 실패해도 다른 예약에 영향 없음
+    // 반환값: 실제로 취소가 수행된 경우 true, 이미 상태 변경된 경우 false
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void cancelIfPending(Long bookingId) {
-        bookingRepository.findByIdWithLock(bookingId).ifPresent(booking -> {
-            if (booking.getStatus() == BookingStatus.PENDING) {
-                booking.cancel("결제 시간 초과로 인한 자동 취소");
-                log.info("예약 ID {} 자동 취소 완료", bookingId);
-            }
-        });
+    public boolean cancelIfPending(Long bookingId) {
+        return bookingRepository.findByIdWithLock(bookingId)
+                .map(booking -> {
+                    if (booking.getStatus() == BookingStatus.PENDING) {
+                        booking.cancel("결제 시간 초과로 인한 자동 취소");
+                        log.info("예약 ID {} 자동 취소 완료", bookingId);
+                        return true;
+                    }
+                    return false;
+                })
+                .orElse(false);
     }
 }

--- a/src/main/java/com/eatsfine/domain/booking/service/BookingCancelExecutor.java
+++ b/src/main/java/com/eatsfine/domain/booking/service/BookingCancelExecutor.java
@@ -1,0 +1,39 @@
+package com.eatsfine.domain.booking.service;
+
+import com.eatsfine.domain.booking.enums.BookingStatus;
+import com.eatsfine.domain.booking.repository.BookingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BookingCancelExecutor {
+
+    private final BookingRepository bookingRepository;
+
+    @Transactional(readOnly = true)
+    public List<Long> findExpiredPendingIds(LocalDateTime threshold) {
+        return bookingRepository.findAllByStatusAndCreatedAtBefore(BookingStatus.PENDING, threshold)
+                .stream()
+                .map(booking -> booking.getId())
+                .toList();
+    }
+
+    // REQUIRES_NEW: 호출마다 독립 트랜잭션 — 하나 실패해도 다른 예약에 영향 없음
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void cancelIfPending(Long bookingId) {
+        bookingRepository.findByIdWithLock(bookingId).ifPresent(booking -> {
+            if (booking.getStatus() == BookingStatus.PENDING) {
+                booking.cancel("결제 시간 초과로 인한 자동 취소");
+                log.info("예약 ID {} 자동 취소 완료", bookingId);
+            }
+        });
+    }
+}

--- a/src/main/java/com/eatsfine/domain/booking/service/BookingCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/domain/booking/service/BookingCommandServiceImpl.java
@@ -32,6 +32,7 @@ import com.eatsfine.domain.user.exception.UserException;
 import com.eatsfine.domain.user.repository.UserRepository;
 import com.eatsfine.domain.user.status.UserErrorStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -126,8 +127,14 @@ public class BookingCommandServiceImpl implements BookingCommandService{
                 .divide(hundred, 0, RoundingMode.HALF_UP);
         booking.setDepositAmount(totalDeposit);
 
-        Booking savedBooking = bookingRepository.save(booking);
-        bookingRepository.flush();
+        Booking savedBooking;
+        try {
+            savedBooking = bookingRepository.save(booking);
+            bookingRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            // uq_booking_table_slot 유니크 제약 위반 — 동시 요청으로 동일 슬롯이 선점된 경우
+            throw new BookingException(BookingErrorStatus._ALREADY_RESERVED_TABLE);
+        }
 
         // 결제 대기 데이터 생성 (내부 서비스 호출)
         PaymentRequestDTO.RequestPaymentDTO paymentRequest = new PaymentRequestDTO.RequestPaymentDTO(savedBooking.getId());

--- a/src/main/java/com/eatsfine/domain/booking/service/BookingCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/domain/booking/service/BookingCommandServiceImpl.java
@@ -167,8 +167,11 @@ public class BookingCommandServiceImpl implements BookingCommandService{
         Booking booking = bookingRepository.findByIdWithLock(bookingId)
                 .orElseThrow(() -> new BookingException(BookingErrorStatus._BOOKING_NOT_FOUND));
 
-        //이미 예약이 확정됐는지 최종 확인
-        if(booking.getStatus() == BookingStatus.CONFIRMED) {
+        if (booking.getStatus() == BookingStatus.CANCELED) {
+            throw new BookingException(BookingErrorStatus._ALREADY_CANCELED);
+        }
+
+        if (booking.getStatus() == BookingStatus.CONFIRMED) {
             throw new BookingException(BookingErrorStatus._ALREADY_CONFIRMED);
         }
 

--- a/src/main/java/com/eatsfine/domain/booking/service/BookingCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/domain/booking/service/BookingCommandServiceImpl.java
@@ -132,8 +132,12 @@ public class BookingCommandServiceImpl implements BookingCommandService{
             savedBooking = bookingRepository.save(booking);
             bookingRepository.flush();
         } catch (DataIntegrityViolationException e) {
-            // uq_booking_table_slot 유니크 제약 위반 — 동시 요청으로 동일 슬롯이 선점된 경우
-            throw new BookingException(BookingErrorStatus._ALREADY_RESERVED_TABLE);
+            // uq_booking_table_slot 위반만 도메인 예외로 변환 — FK/NOT NULL 등 다른 위반은 원본 그대로 전파
+            String cause = e.getMostSpecificCause().getMessage();
+            if (cause != null && cause.contains("uq_booking_table_slot")) {
+                throw new BookingException(BookingErrorStatus._ALREADY_RESERVED_TABLE, e);
+            }
+            throw e;
         }
 
         // 결제 대기 데이터 생성 (내부 서비스 호출)

--- a/src/main/java/com/eatsfine/domain/booking/service/BookingCommandServiceImpl.java
+++ b/src/main/java/com/eatsfine/domain/booking/service/BookingCommandServiceImpl.java
@@ -153,7 +153,7 @@ public class BookingCommandServiceImpl implements BookingCommandService{
     @Transactional
     public BookingResponseDTO.ConfirmPaymentResultDTO confirmPayment(Long bookingId, BookingRequestDTO.PaymentConfirmDTO dto) {
 
-        Booking booking = bookingRepository.findById(bookingId)
+        Booking booking = bookingRepository.findByIdWithLock(bookingId)
                 .orElseThrow(() -> new BookingException(BookingErrorStatus._BOOKING_NOT_FOUND));
 
         //이미 예약이 확정됐는지 최종 확인
@@ -182,7 +182,7 @@ public class BookingCommandServiceImpl implements BookingCommandService{
     public BookingResponseDTO.CancelBookingResultDTO cancelBooking(Long userId, Long bookingId, BookingRequestDTO.CancelBookingDTO dto) {
 
 
-        Booking booking = bookingRepository.findById(bookingId)
+        Booking booking = bookingRepository.findByIdWithLock(bookingId)
                 .orElseThrow(() -> new BookingException(BookingErrorStatus._BOOKING_NOT_FOUND));
 
 
@@ -220,7 +220,7 @@ public class BookingCommandServiceImpl implements BookingCommandService{
         storeValidator.validateStoreOwner(storeId, email);
 
         // 1. 예약 존재 확인
-        Booking booking = bookingRepository.findById(bookingId)
+        Booking booking = bookingRepository.findByIdWithLock(bookingId)
                 .orElseThrow(() -> new BookingException(BookingErrorStatus._BOOKING_NOT_FOUND));
 
         // 2. 데이터 무결성 검증

--- a/src/main/java/com/eatsfine/domain/booking/service/BookingScheduler.java
+++ b/src/main/java/com/eatsfine/domain/booking/service/BookingScheduler.java
@@ -1,13 +1,9 @@
 package com.eatsfine.domain.booking.service;
 
-import com.eatsfine.domain.booking.entity.Booking;
-import com.eatsfine.domain.booking.enums.BookingStatus;
-import com.eatsfine.domain.booking.repository.BookingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,36 +13,37 @@ import java.util.List;
 @Slf4j
 public class BookingScheduler {
 
-    private final BookingRepository bookingRepository;
+    private final BookingCancelExecutor bookingCancelExecutor;
 
     /**
      * 결제 미완료(PENDING) 상태로 10분이 경과한 예약을 주기적으로 취소 처리
      * cron: 0분부터 10분 단위로 실행 (0, 10, 20, 30, 40, 50분)
+     *
+     * 각 예약을 독립 트랜잭션(REQUIRES_NEW)으로 처리하여
+     * 낙관적 락 충돌 등 일부 실패가 전체 배치에 영향을 주지 않음
      */
     @Scheduled(cron = "0 0/10 * * * *")
-    @Transactional
     public void cleanupExpiredPendingBookings() {
         LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
 
-        // 1. 10분 전보다 이전에 생성되었고, 여전히 PENDING인 예약 조회
-        List<Booking> expiredBookings = bookingRepository.findAllByStatusAndCreatedAtBefore(
-                BookingStatus.PENDING,
-                threshold
-        );
+        List<Long> expiredIds = bookingCancelExecutor.findExpiredPendingIds(threshold);
 
-        if (expiredBookings.isEmpty()) {
+        if (expiredIds.isEmpty()) {
             return;
         }
 
-        log.info("스케줄러 실행: 만료된 PENDING 예약 {}건을 취소 처리합니다.", expiredBookings.size());
+        log.info("스케줄러 실행: 만료된 PENDING 예약 {}건 처리 시작", expiredIds.size());
 
-        // 2. 상태 변경 및 로그 기록
-        expiredBookings.forEach(booking -> {
-            // 조회 후 상태가 변경되었을 수 있으므로 PENDING 여부를 재확인
-            if (booking.getStatus() == BookingStatus.PENDING) {
-                booking.cancel("결제 시간 초과로 인한 자동 취소");
+        int successCount = 0;
+        for (Long id : expiredIds) {
+            try {
+                bookingCancelExecutor.cancelIfPending(id);
+                successCount++;
+            } catch (Exception e) {
+                log.warn("예약 ID {} 자동 취소 실패 — 다음 실행에서 재시도: {}", id, e.getMessage());
             }
-        });
+        }
 
+        log.info("스케줄러 완료: {}건 성공 / {}건 시도", successCount, expiredIds.size());
     }
 }

--- a/src/main/java/com/eatsfine/domain/booking/service/BookingScheduler.java
+++ b/src/main/java/com/eatsfine/domain/booking/service/BookingScheduler.java
@@ -3,11 +3,11 @@ package com.eatsfine.domain.booking.service;
 import com.eatsfine.domain.booking.entity.Booking;
 import com.eatsfine.domain.booking.enums.BookingStatus;
 import com.eatsfine.domain.booking.repository.BookingRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -42,7 +42,10 @@ public class BookingScheduler {
 
         // 2. 상태 변경 및 로그 기록
         expiredBookings.forEach(booking -> {
-            booking.cancel("결제 시간 초과로 인한 자동 취소");
+            // 조회 후 상태가 변경되었을 수 있으므로 PENDING 여부를 재확인
+            if (booking.getStatus() == BookingStatus.PENDING) {
+                booking.cancel("결제 시간 초과로 인한 자동 취소");
+            }
         });
 
     }

--- a/src/main/java/com/eatsfine/domain/booking/service/BookingScheduler.java
+++ b/src/main/java/com/eatsfine/domain/booking/service/BookingScheduler.java
@@ -34,16 +34,18 @@ public class BookingScheduler {
 
         log.info("스케줄러 실행: 만료된 PENDING 예약 {}건 처리 시작", expiredIds.size());
 
-        int successCount = 0;
+        int canceledCount = 0;
+        int skippedCount = 0;
         for (Long id : expiredIds) {
             try {
-                bookingCancelExecutor.cancelIfPending(id);
-                successCount++;
+                if (bookingCancelExecutor.cancelIfPending(id)) canceledCount++;
+                else skippedCount++;
             } catch (Exception e) {
                 log.warn("예약 ID {} 자동 취소 실패 — 다음 실행에서 재시도: {}", id, e.getMessage());
             }
         }
 
-        log.info("스케줄러 완료: {}건 성공 / {}건 시도", successCount, expiredIds.size());
+        log.info("스케줄러 완료: 취소 {}건 / 스킵 {}건 / 시도 {}건",
+                canceledCount, skippedCount, expiredIds.size());
     }
 }

--- a/src/main/java/com/eatsfine/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/eatsfine/domain/payment/service/PaymentService.java
@@ -2,7 +2,9 @@ package com.eatsfine.domain.payment.service;
 
 import com.eatsfine.domain.booking.entity.Booking;
 import com.eatsfine.domain.booking.enums.BookingStatus;
+import com.eatsfine.domain.booking.exception.BookingException;
 import com.eatsfine.domain.booking.repository.BookingRepository;
+import com.eatsfine.domain.booking.status.BookingErrorStatus;
 import com.eatsfine.domain.payment.dto.request.PaymentWebhookDTO;
 import com.eatsfine.domain.payment.dto.request.PaymentConfirmDTO;
 import com.eatsfine.domain.payment.dto.request.PaymentRequestDTO;
@@ -120,8 +122,27 @@ public class PaymentService {
                 if (booking != null) {
                         // 비관적 락으로 재조회하여 스케줄러 / 다른 스레드와의 동시 수정 방지
                         Booking lockedBooking = bookingRepository.findByIdWithLock(booking.getId())
-                                .orElse(null);
-                        if (lockedBooking != null && lockedBooking.getStatus() == BookingStatus.PENDING) {
+                                .orElseThrow(() -> new PaymentException(PaymentErrorStatus._BOOKING_NOT_FOUND));
+
+                        if (lockedBooking.getStatus() == BookingStatus.CONFIRMED) {
+                                // 멱등성: 이미 확정된 경우 중복 처리 방지
+                                log.info("Booking {} already CONFIRMED (idempotent), skipping update for OrderID: {}",
+                                                lockedBooking.getId(), dto.orderId());
+                        } else if (lockedBooking.getStatus() == BookingStatus.CANCELED) {
+                                // 보상 처리: 스케줄러 등에 의해 예약이 취소됐으나 결제가 완료된 경우 자동 환불
+                                log.warn("Booking {} is CANCELED but payment was completed. Triggering compensation refund for OrderID: {}",
+                                                lockedBooking.getId(), dto.orderId());
+                                try {
+                                        tossPaymentService.cancel(response.paymentKey(),
+                                                        new PaymentRequestDTO.CancelPaymentDTO("예약 취소 상태에서 결제 완료 - 자동 환불"));
+                                } catch (Exception refundEx) {
+                                        log.error("Compensation refund failed for OrderID: {}. Manual intervention required.",
+                                                        dto.orderId(), refundEx);
+                                }
+                                payment.cancelPayment();
+                                // noRollbackFor = GeneralException.class 이므로 payment.cancelPayment() 변경은 커밋됨
+                                throw new BookingException(BookingErrorStatus._ALREADY_CANCELED);
+                        } else {
                                 lockedBooking.confirm();
                                 log.info("Booking confirmed for OrderID: {}", dto.orderId());
                         }

--- a/src/main/java/com/eatsfine/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/eatsfine/domain/payment/service/PaymentService.java
@@ -121,7 +121,7 @@ public class PaymentService {
                         // 비관적 락으로 재조회하여 스케줄러 / 다른 스레드와의 동시 수정 방지
                         Booking lockedBooking = bookingRepository.findByIdWithLock(booking.getId())
                                 .orElse(null);
-                        if (lockedBooking != null && lockedBooking.getStatus() != BookingStatus.CONFIRMED) {
+                        if (lockedBooking != null && lockedBooking.getStatus() == BookingStatus.PENDING) {
                                 lockedBooking.confirm();
                                 log.info("Booking confirmed for OrderID: {}", dto.orderId());
                         }

--- a/src/main/java/com/eatsfine/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/eatsfine/domain/payment/service/PaymentService.java
@@ -1,6 +1,7 @@
 package com.eatsfine.domain.payment.service;
 
 import com.eatsfine.domain.booking.entity.Booking;
+import com.eatsfine.domain.booking.enums.BookingStatus;
 import com.eatsfine.domain.booking.repository.BookingRepository;
 import com.eatsfine.domain.payment.dto.request.PaymentWebhookDTO;
 import com.eatsfine.domain.payment.dto.request.PaymentConfirmDTO;
@@ -115,11 +116,15 @@ public class PaymentService {
                                 provider,
                                 response.receipt() != null ? response.receipt().url() : null);
 
-                Booking booking = payment.getBooking(); // 결제 엔티티에 매핑된 예약 객체 가져오기
+                Booking booking = payment.getBooking();
                 if (booking != null) {
-                        // 예약 상태를 CONFIRMED로 변경
-                        booking.confirm();
-                        log.info("Booking confirmed for OrderID: {}", dto.orderId());
+                        // 비관적 락으로 재조회하여 스케줄러 / 다른 스레드와의 동시 수정 방지
+                        Booking lockedBooking = bookingRepository.findByIdWithLock(booking.getId())
+                                .orElse(null);
+                        if (lockedBooking != null && lockedBooking.getStatus() != BookingStatus.CONFIRMED) {
+                                lockedBooking.confirm();
+                                log.info("Booking confirmed for OrderID: {}", dto.orderId());
+                        }
                 }
 
 

--- a/src/main/java/com/eatsfine/global/apipayload/exception/GeneralException.java
+++ b/src/main/java/com/eatsfine/global/apipayload/exception/GeneralException.java
@@ -5,8 +5,17 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class GeneralException extends RuntimeException {
 
     private final BaseErrorCode code;
+
+    public GeneralException(BaseErrorCode code) {
+        super(code.getReason().getMessage());
+        this.code = code;
+    }
+
+    public GeneralException(BaseErrorCode code, Throwable cause) {
+        super(code.getReason().getMessage(), cause);
+        this.code = code;
+    }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -17,11 +17,15 @@ spring:
       port: ${REDIS_PORT}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:
         format_sql: true
+  flyway:
+    enabled: true
+    baseline-on-migrate: true  # 기존 DB(Flyway 미적용 상태)를 version 0 베이스라인으로 처리
+    baseline-version: 0
   security:
     oauth2:
       client:

--- a/src/main/resources/db/migration/V1__add_booking_table_slot_constraints.sql
+++ b/src/main/resources/db/migration/V1__add_booking_table_slot_constraints.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- V1: booking_table 슬롯 유니크 제약 및 Booking 낙관적 락 추가
+-- ============================================================
+-- 목적: 동시 예약 오버부킹 방지를 위한 DB 레벨 유니크 제약 추가
+-- 영향 테이블: booking_table, booking
+-- ============================================================
+
+-- [Step 1] 새 컬럼 추가 — NULL 허용으로 먼저 추가 (기존 행 오류 방지)
+ALTER TABLE booking_table
+    ADD COLUMN booking_date DATE        NULL,
+    ADD COLUMN booking_time TIME        NULL,
+    ADD COLUMN is_active    TINYINT(1)  NULL;
+
+-- [Step 2] 기존 booking_table 행에 booking 테이블의 날짜/시간 백필
+--          CONFIRMED / PENDING 상태: is_active = 1 (활성 슬롯)
+--          그 외 (CANCELED 등): is_active = NULL (슬롯 해제, 유니크 제약 제외)
+UPDATE booking_table bt
+    INNER JOIN booking b ON bt.booking_id = b.id
+SET bt.booking_date = b.booking_date,
+    bt.booking_time = b.booking_time,
+    bt.is_active    = CASE
+        WHEN b.status IN ('CONFIRMED', 'PENDING') THEN 1
+        ELSE NULL
+    END;
+
+-- [Step 3] 백필 완료 후 NOT NULL 적용
+ALTER TABLE booking_table
+    MODIFY COLUMN booking_date DATE NOT NULL,
+    MODIFY COLUMN booking_time TIME NOT NULL;
+
+-- [Step 4] 유니크 제약 추가
+--          is_active가 NULL이면 MySQL 유니크 인덱스에서 중복 체크 제외
+--          → 취소된 슬롯에 재예약 가능
+ALTER TABLE booking_table
+    ADD CONSTRAINT uq_booking_table_slot
+        UNIQUE (store_table_id, booking_date, booking_time, is_active);
+
+-- [Step 5] Booking 낙관적 락(@Version) 컬럼 추가 — NULL 허용 (JPA가 첫 write 시 0으로 초기화)
+ALTER TABLE booking
+    ADD COLUMN version BIGINT NULL;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,6 +8,8 @@ spring:
     driver-class-name: org.h2.Driver
     username:
     password:
+  flyway:
+    enabled: false  # 테스트는 H2 ddl-auto:create-drop으로 스키마 관리
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION
### 💡 작업 개요
예약 생성·확인·취소 및 결제 확인 흐름에서 동시 요청이 들어올 때 발생할 수 있는 레이스 컨디션을 수정합니다.
오버부킹(이중 예약), 확정된 예약의 자동 취소, 중복 상태 변경 등의 데이터 정합성 문제를 방지합니다.

### ✅ 작업 내용
- [x] 버그 수정
- [x] 기타 설정 (Flyway 도입)

### 📋 상세 작업 내용

**[CRITICAL] 스케줄러 트랜잭션 오용 수정**
- `BookingScheduler`: `jakarta.transaction.Transactional` → Spring `@Transactional` 교체
- 배치를 `BookingCancelExecutor`로 분리 — 예약별 독립 트랜잭션(`REQUIRES_NEW`)으로 처리하여 낙관적 락 충돌 시 해당 예약만 실패하고 나머지 배치는 정상 처리

**[CRITICAL] Booking 낙관적 락 추가**
- `Booking` 엔티티에 `@Version private Long version` 추가
- 동시에 두 스레드가 `booking.confirm()` / `booking.cancel()`을 호출하면 두 번째 커밋 시 `OptimisticLockingFailureException` 발생

**[CRITICAL] BookingTable DB 유니크 제약 추가 (소프트 딜리트 방식)**
- `BookingTable`에 `booking_date`, `booking_time`, `is_active`(nullable) 컬럼 추가
- `(store_table_id, booking_date, booking_time, is_active)` 유니크 제약 추가
- 예약 취소 시 `is_active = null`로 슬롯 해제 — MySQL NULL 특성으로 취소 슬롯 재예약 허용, 이력 데이터 보존

**[HIGH] Booking 비관적 락 메서드 추가 및 적용**
- `BookingRepository.findByIdWithLock()` 추가 (`@Lock(PESSIMISTIC_WRITE)`)
- `confirmPayment()`, `cancelBooking()`, `cancelBookingByOwner()`, `PaymentService.confirmPayment()`에 락 적용
- `PaymentService`: Booking 상태 전이 조건을 `PENDING`으로 한정 (COMPLETED/CANCELED 덮어쓰기 방지)

**[MEDIUM] DB 예외 도메인 변환**
- `DataIntegrityViolationException` → `BookingException(_ALREADY_RESERVED_TABLE)` 변환
- 동시 요청 시 500 대신 409 Conflict 응답 반환

**[CHORE] Flyway 도입**
- `ddl-auto: update` 의존에서 벗어나 안전한 단계별 마이그레이션 적용
- `V1`: booking_date/time NULL 허용 추가 → 백필 → NOT NULL 변환 → 유니크 제약 추가

### ⚠️ DB 스키마 변경 포함 — Slack 공유 후 머지

**Flyway V1 마이그레이션이 서버 시작 시 자동 실행됩니다:**
- `booking_table`: `booking_date`, `booking_time`, `is_active` 컬럼 추가
- `booking_table`: 유니크 제약 `uq_booking_table_slot` 추가
- `booking`: `version` 컬럼 추가

**prod 환경 적용 전 `application-prod.yml`에 아래 설정 추가 필요 (담당자 직접 수정):**
```yaml
spring:
  jpa:
    hibernate:
      ddl-auto: validate
  flyway:
    enabled: true
    baseline-on-migrate: true
    baseline-version: 0
```

### 🧪 테스트 내용
- `./gradlew test` 전체 통과

### 📝 기타 참고 사항
- Closes #157
- Entity 변경 + Flyway 도입 → **최소 2명 승인 필수**
- **머지 전 Slack 팀 공유 필수**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 예약 슬롯 중복 방지 로직 강화
  * 만료된 대기 예약 자동 정리 절차 개선

* **버그 수정**
  * 예약 취소 시 관련 테이블 상태 업데이트 안정화
  * 동시성 상황에서 예약 충돌·데이터 무결성 처리 개선
  * 결제 확인 시 예약 상태 검증 및 보상 처리 보강

* **Chores**
  * 데이터베이스 마이그레이션 도구 추가 및 로컬/테스트 환경 설정 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->